### PR TITLE
Refactor server.py: compress descriptions, inline handlers

### DIFF
--- a/src/mcp_latex_tools/server.py
+++ b/src/mcp_latex_tools/server.py
@@ -181,7 +181,7 @@ async def list_resources() -> list[Resource]:
 
 
 @server.read_resource()
-async def read_resource(uri: str) -> str:
+async def read_resource(uri: AnyUrl) -> str:
     """Read resource content."""
     uri_str = str(uri)
     if uri_str == "latex://config/cleanup-extensions":

--- a/src/mcp_latex_tools/server.py
+++ b/src/mcp_latex_tools/server.py
@@ -1,581 +1,581 @@
 """MCP server for LaTeX compilation and PDF tools."""
 
 import asyncio
+import json
 import logging
 
 from mcp.server import Server
-from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import (
-    CallToolRequest,
-    CallToolResult,
-    CallToolRequestParams,
-    ListToolsResult,
     Tool,
     TextContent,
-    ServerCapabilities,
-    ToolsCapability,
+    Resource,
+    Prompt,
+    PromptArgument,
+    PromptMessage,
+    GetPromptResult,
+    AnyUrl,
 )
 
 from mcp_latex_tools.tools.compile import compile_latex, CompilationError
 from mcp_latex_tools.tools.validate import validate_latex, ValidationError
 from mcp_latex_tools.tools.pdf_info import extract_pdf_info, PDFInfoError
-from mcp_latex_tools.tools.cleanup import clean_latex, CleanupError
+from mcp_latex_tools.tools.cleanup import (
+    clean_latex,
+    CleanupError,
+    DEFAULT_CLEANUP_EXTENSIONS,
+    PROTECTED_EXTENSIONS,
+)
+from mcp_latex_tools.utils.log_parser import get_error_summary
 
-
-# Configure logging
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
-# Create MCP server instance
 server: Server = Server("mcp-latex-tools")
-logger.debug(f"Server created with name: {server.name}")
 
 
 @server.list_tools()
 async def list_tools() -> list[Tool]:
     """List available LaTeX tools."""
-    logger.debug("list_tools called")
     return [
-            Tool(
-                name="compile_latex",
-                description="Compile LaTeX files to PDF with comprehensive error handling",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "tex_path": {
-                            "type": "string",
-                            "description": "Path to the .tex file to compile",
-                        },
-                        "output_dir": {
-                            "type": "string",
-                            "description": "Directory for output (defaults to same as input)",
-                        },
-                        "timeout": {
-                            "type": "integer",
-                            "description": "Maximum seconds to wait for compilation",
-                            "default": 30,
-                        },
+        Tool(
+            name="compile_latex",
+            description="Compile .tex to PDF via pdflatex. Creates .pdf/.aux/.log. Returns path, timing, errors.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "tex_path": {
+                        "type": "string",
+                        "description": "Path to the .tex file to compile",
                     },
-                    "required": ["tex_path"],
-                },
-            ),
-            Tool(
-                name="validate_latex",
-                description="Validate LaTeX syntax without full compilation",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "file_path": {
-                            "type": "string",
-                            "description": "Path to the .tex file to validate",
-                        },
-                        "quick": {
-                            "type": "boolean",
-                            "description": "Perform quick syntax check only (mutually exclusive with strict)",
-                            "default": False,
-                        },
-                        "strict": {
-                            "type": "boolean",
-                            "description": "Perform thorough validation with style checks (mutually exclusive with quick)",
-                            "default": False,
-                        },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "Directory for output files (default: same as input)",
                     },
-                    "required": ["file_path"],
-                },
-            ),
-            Tool(
-                name="pdf_info",
-                description="Extract PDF metadata and information without compilation",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "file_path": {
-                            "type": "string",
-                            "description": "Path to the PDF file to analyze",
-                        },
-                        "include_text": {
-                            "type": "boolean",
-                            "description": "Extract text content from PDF pages",
-                            "default": False,
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "Password for encrypted PDFs (optional)",
-                        },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Max compilation time in seconds",
+                        "default": 30,
+                        "minimum": 5,
+                        "maximum": 300,
                     },
-                    "required": ["file_path"],
                 },
-            ),
-            Tool(
-                name="cleanup",
-                description="Clean LaTeX auxiliary files (.aux, .log, .out, etc.) from directories or individual files",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "type": "string",
-                            "description": "Path to .tex file or directory to clean",
-                        },
-                        "extensions": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "List of file extensions to clean (defaults to common auxiliary files)",
-                        },
-                        "dry_run": {
-                            "type": "boolean",
-                            "description": "Show what would be cleaned without removing files",
-                            "default": False,
-                        },
-                        "recursive": {
-                            "type": "boolean",
-                            "description": "Clean subdirectories recursively",
-                            "default": False,
-                        },
-                        "create_backup": {
-                            "type": "boolean",
-                            "description": "Create backup of files before deletion",
-                            "default": False,
-                        },
+                "required": ["tex_path"],
+            },
+        ),
+        Tool(
+            name="validate_latex",
+            description="Check LaTeX syntax without compiling. Modes: quick, default, strict. Returns errors/warnings.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Path to the .tex file to validate",
                     },
-                    "required": ["path"],
+                    "quick": {
+                        "type": "boolean",
+                        "description": "Quick mode: structure only",
+                        "default": False,
+                    },
+                    "strict": {
+                        "type": "boolean",
+                        "description": "Strict mode: include style checks",
+                        "default": False,
+                    },
                 },
-            ),
-        ]
+                "required": ["file_path"],
+            },
+        ),
+        Tool(
+            name="pdf_info",
+            description="Extract PDF metadata: pages, dimensions, title, author, dates. Optional text extraction.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Path to the PDF file to analyze",
+                    },
+                    "include_text": {
+                        "type": "boolean",
+                        "description": "Extract text content from pages",
+                        "default": False,
+                    },
+                    "password": {
+                        "type": "string",
+                        "description": "Password for encrypted PDFs",
+                    },
+                },
+                "required": ["file_path"],
+            },
+        ),
+        Tool(
+            name="cleanup",
+            description="Remove LaTeX auxiliary files (.aux, .log, etc.). Supports dry_run, recursive, backup. Never deletes .tex/.pdf/.bib.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to .tex file or directory to clean",
+                    },
+                    "extensions": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Custom extensions to clean (default: .aux, .log, .out, etc.)",
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "Preview what would be deleted without deleting",
+                        "default": False,
+                    },
+                    "recursive": {
+                        "type": "boolean",
+                        "description": "Clean subdirectories recursively",
+                        "default": False,
+                    },
+                    "create_backup": {
+                        "type": "boolean",
+                        "description": "Create backup before deleting",
+                        "default": False,
+                    },
+                },
+                "required": ["path"],
+            },
+        ),
+    ]
+
+
+# =============================================================================
+# MCP Resources
+# =============================================================================
+
+
+@server.list_resources()
+async def list_resources() -> list[Resource]:
+    """List available LaTeX resources."""
+    return [
+        Resource(
+            uri=AnyUrl("latex://config/cleanup-extensions"),
+            name="Cleanup Extensions",
+            description="File extensions removed by the cleanup tool",
+            mimeType="application/json",
+        ),
+        Resource(
+            uri=AnyUrl("latex://config/protected-extensions"),
+            name="Protected Extensions",
+            description="File extensions protected from cleanup (never deleted)",
+            mimeType="application/json",
+        ),
+        Resource(
+            uri=AnyUrl("latex://help/workflow"),
+            name="Workflow Guide",
+            description="Recommended workflow for LaTeX document compilation",
+            mimeType="text/markdown",
+        ),
+    ]
+
+
+@server.read_resource()
+async def read_resource(uri: str) -> str:
+    """Read resource content."""
+    if uri == "latex://config/cleanup-extensions":
+        return json.dumps(
+            {
+                "extensions": sorted(DEFAULT_CLEANUP_EXTENSIONS),
+                "description": "File extensions removed by the cleanup tool",
+                "count": len(DEFAULT_CLEANUP_EXTENSIONS),
+            },
+            indent=2,
+        )
+
+    elif uri == "latex://config/protected-extensions":
+        return json.dumps(
+            {
+                "extensions": sorted(PROTECTED_EXTENSIONS),
+                "description": "File extensions protected from cleanup (never deleted)",
+                "count": len(PROTECTED_EXTENSIONS),
+            },
+            indent=2,
+        )
+
+    elif uri == "latex://help/workflow":
+        return """# LaTeX Compilation Workflow
+
+1. **Validate**: `validate_latex` — catch syntax errors fast
+2. **Compile**: `compile_latex` — generate PDF
+3. **Verify**: `pdf_info` — check page count and metadata
+4. **Cleanup**: `cleanup` with `dry_run=true` first, then without
+
+## Error Recovery
+If compilation fails, run `validate_latex` to identify syntax errors.
+If validation passes but compilation fails, check for missing packages or increase timeout.
+"""
+
+    raise ValueError(f"Unknown resource: {uri}")
+
+
+# =============================================================================
+# MCP Prompts
+# =============================================================================
+
+
+@server.list_prompts()
+async def list_prompts() -> list[Prompt]:
+    """List available LaTeX workflow prompts."""
+    return [
+        Prompt(
+            name="compile-and-verify",
+            description="Complete workflow: validate, compile, verify PDF, and clean up",
+            arguments=[
+                PromptArgument(
+                    name="tex_path",
+                    description="Path to the .tex file to compile",
+                    required=True,
+                ),
+                PromptArgument(
+                    name="cleanup",
+                    description="Whether to clean auxiliary files after (true/false)",
+                    required=False,
+                ),
+            ],
+        ),
+        Prompt(
+            name="diagnose-compilation-error",
+            description="Diagnose why a LaTeX document fails to compile",
+            arguments=[
+                PromptArgument(
+                    name="tex_path",
+                    description="Path to the .tex file that failed to compile",
+                    required=True,
+                ),
+            ],
+        ),
+        Prompt(
+            name="prepare-fresh-build",
+            description="Clean all auxiliary files and recompile from scratch",
+            arguments=[
+                PromptArgument(
+                    name="tex_path",
+                    description="Path to the .tex file to rebuild",
+                    required=True,
+                ),
+            ],
+        ),
+    ]
+
+
+@server.get_prompt()
+async def get_prompt(name: str, arguments: dict | None = None) -> GetPromptResult:
+    """Get prompt messages for a specific workflow."""
+    args = arguments or {}
+
+    if name == "compile-and-verify":
+        tex_path = args.get("tex_path", "<tex_path>")
+        do_cleanup = str(args.get("cleanup", "true")).lower() == "true"
+        cleanup_step = (
+            "\n4. **CLEANUP**: Run `cleanup` on the .tex file path to remove auxiliary files."
+            if do_cleanup
+            else "\n4. **SKIP CLEANUP**: User requested no cleanup."
+        )
+        return GetPromptResult(
+            description=f"Complete compilation workflow for {tex_path}",
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(
+                        type="text",
+                        text=f"""Execute a complete LaTeX compilation workflow for: {tex_path}
+
+Follow these steps in order:
+
+1. **VALIDATE**: Run `validate_latex` on "{tex_path}" to check for syntax errors.
+   - If errors found, report them and stop.
+   - If only warnings, continue but note them.
+
+2. **COMPILE**: Run `compile_latex` on "{tex_path}".
+   - If compilation fails, report the error summary.
+   - If successful, proceed to verification.
+
+3. **VERIFY**: Run `pdf_info` on the generated PDF.
+   - Report page count and file size.
+   - Confirm the PDF was created successfully.
+{cleanup_step}
+
+Report results at each step. Summarize the final outcome.""",
+                    ),
+                ),
+            ],
+        )
+
+    elif name == "diagnose-compilation-error":
+        tex_path = args.get("tex_path", "<tex_path>")
+        return GetPromptResult(
+            description=f"Diagnose compilation errors for {tex_path}",
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(
+                        type="text",
+                        text=f"""Diagnose compilation issues for: {tex_path}
+
+Follow this diagnostic procedure:
+
+1. **VALIDATE (Quick)**: Run `validate_latex` with `quick=true`.
+2. **VALIDATE (Full)**: If quick passes, run `validate_latex` with default settings.
+3. **VALIDATE (Strict)**: If full passes, run `validate_latex` with `strict=true`.
+4. **ATTEMPT COMPILATION**: If validation passes, try `compile_latex` with `timeout=60`.
+5. **DIAGNOSIS**: Based on all results, provide root cause, line numbers, and suggested fixes.""",
+                    ),
+                ),
+            ],
+        )
+
+    elif name == "prepare-fresh-build":
+        tex_path = args.get("tex_path", "<tex_path>")
+        return GetPromptResult(
+            description=f"Fresh build workflow for {tex_path}",
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(
+                        type="text",
+                        text=f"""Perform a fresh build for: {tex_path}
+
+Steps:
+
+1. **PREVIEW CLEANUP**: Run `cleanup` with `dry_run=true` to see what would be removed.
+2. **CLEAN**: Run `cleanup` with `create_backup=true` to safely remove auxiliary files.
+3. **VALIDATE**: Run `validate_latex` to ensure the source file is ready.
+4. **COMPILE**: Run `compile_latex` to rebuild from scratch.
+5. **VERIFY**: Run `pdf_info` on the new PDF.""",
+                    ),
+                ),
+            ],
+        )
+
+    raise ValueError(f"Unknown prompt: {name}")
+
+
+# =============================================================================
+# Tool Call Handler
+# =============================================================================
+
+
+def _text_result(text: str) -> list[TextContent]:
+    """Return a single TextContent list."""
+    return [TextContent(type="text", text=text)]
 
 
 @server.call_tool()
-async def call_tool(tool_name: str, arguments: dict) -> list[TextContent]:
+async def call_tool(tool_name: str, arguments: dict) -> list[TextContent]:  # type: ignore[override]
     """Handle tool calls."""
     try:
-        logger.debug(f"call_tool called with name={tool_name}, arguments={arguments}")
-        
         if tool_name == "compile_latex":
-            # Create a mock request object for backward compatibility
-            request = CallToolRequest(
-                method="tools/call",
-                params=CallToolRequestParams(name=tool_name, arguments=arguments)
-            )
-            result = await handle_compile_latex(request)
-            return result.content
+            return await _handle_compile(arguments)
         elif tool_name == "validate_latex":
-            request = CallToolRequest(
-                method="tools/call",
-                params=CallToolRequestParams(name=tool_name, arguments=arguments)
-            )
-            result = await handle_validate_latex(request)
-            return result.content
+            return await _handle_validate(arguments)
         elif tool_name == "pdf_info":
-            request = CallToolRequest(
-                method="tools/call",
-                params=CallToolRequestParams(name=tool_name, arguments=arguments)
-            )
-            result = await handle_pdf_info(request)
-            return result.content
+            return await _handle_pdf_info(arguments)
         elif tool_name == "cleanup":
-            request = CallToolRequest(
-                method="tools/call",
-                params=CallToolRequestParams(name=tool_name, arguments=arguments)
-            )
-            result = await handle_cleanup(request)
-            return result.content
+            return await _handle_cleanup(arguments)
         else:
             raise ValueError(f"Unknown tool: {tool_name}")
     except Exception as e:
-        logger.error(f"Error in tool call {tool_name}: {e}")
-        return [
-            TextContent(
-                type="text",
-                text=f"Error: {str(e)}",
-            )
-        ]
+        logger.error("Error in tool call %s: %s", tool_name, e)
+        return _text_result(f"Error: {e}")
 
 
-async def handle_compile_latex(request: CallToolRequest) -> CallToolResult:
-    """Handle LaTeX compilation requests."""
-    args = request.params.arguments or {}
-    
-    # Extract arguments
+async def _handle_compile(args: dict) -> list[TextContent]:
     tex_path = args.get("tex_path")
-    output_dir = args.get("output_dir")
-    timeout = args.get("timeout", 30)
-    
     if not tex_path:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text="Error: tex_path is required",
-                )
-            ]
-        )
-    
+        return _text_result("Error: tex_path is required")
+
     try:
-        # Run compilation in executor to avoid blocking
         loop = asyncio.get_event_loop()
         result = await loop.run_in_executor(
             None,
             compile_latex,
             tex_path,
-            output_dir,
-            timeout,
+            args.get("output_dir"),
+            args.get("timeout", 30),
         )
-        
-        # Format response
+
         if result.success:
-            response_text = "✓ LaTeX compilation successful!\n"
-            response_text += f"Output: {result.output_path}\n"
+            text = f"Compilation successful\nOutput: {result.output_path}"
             if result.compilation_time_seconds:
-                response_text += f"Compilation time: {result.compilation_time_seconds:.2f}s\n"
+                text += f"\nCompilation time: {result.compilation_time_seconds:.2f}s"
         else:
-            response_text = "✗ LaTeX compilation failed\n"
+            text = "Compilation failed"
             if result.error_message:
-                response_text += f"Error: {result.error_message}\n"
+                text += f"\nError: {result.error_message}"
             if result.compilation_time_seconds:
-                response_text += f"Compilation time: {result.compilation_time_seconds:.2f}s\n"
-        
-        # Include log content if available
-        if result.log_content:
-            response_text += f"\nLog content:\n{result.log_content}"
-        
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=response_text,
-                )
-            ]
-        )
-        
+                text += f"\nCompilation time: {result.compilation_time_seconds:.2f}s"
+            if result.log_content:
+                text += f"\n{get_error_summary(result.log_content)}"
+        return _text_result(text)
+
     except CompilationError as e:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"Compilation error: {str(e)}",
-                )
-            ]
-        )
-    except Exception as e:
-        logger.error(f"Unexpected error in compile_latex: {e}")
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"Unexpected error: {str(e)}",
-                )
-            ]
-        )
+        return _text_result(f"Compilation error: {e}")
 
 
-async def handle_validate_latex(request: CallToolRequest) -> CallToolResult:
-    """Handle LaTeX validation requests."""
-    args = request.params.arguments or {}
-    
-    # Extract arguments
+async def _handle_validate(args: dict) -> list[TextContent]:
     file_path = args.get("file_path")
-    quick = args.get("quick", False)
-    strict = args.get("strict", False)
-    
     if not file_path:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text="Error: file_path is required",
-                )
-            ]
-        )
-    
+        return _text_result("Error: file_path is required")
+
     try:
-        # Run validation in executor to avoid blocking
         loop = asyncio.get_event_loop()
         result = await loop.run_in_executor(
             None,
             validate_latex,
             file_path,
-            quick,
-            strict,
+            args.get("quick", False),
+            args.get("strict", False),
         )
-        
-        # Format response
+
         if result.is_valid:
-            response_text = "✓ Valid LaTeX syntax\n"
-            response_text += "No errors found\n"
+            text = "Valid LaTeX syntax\nNo errors found"
             if result.warnings:
-                response_text += f"Warnings ({len(result.warnings)}):\n"
-                for warning in result.warnings:
-                    response_text += f"  • {warning}\n"
+                text += f"\nWarnings ({len(result.warnings)}):"
+                for w in result.warnings:
+                    text += f"\n  - {w}"
         else:
-            response_text = "✗ Invalid LaTeX syntax\n"
-            response_text += f"Errors found ({len(result.errors)}):\n"
-            for error in result.errors:
-                response_text += f"  • {error}\n"
+            text = f"Invalid LaTeX syntax\nErrors found ({len(result.errors)}):"
+            for e in result.errors:
+                text += f"\n  - {e}"
             if result.warnings:
-                response_text += f"Warnings ({len(result.warnings)}):\n"
-                for warning in result.warnings:
-                    response_text += f"  • {warning}\n"
-        
-        # Include validation time
+                text += f"\nWarnings ({len(result.warnings)}):"
+                for w in result.warnings:
+                    text += f"\n  - {w}"
+
         if result.validation_time_seconds:
-            response_text += f"Validation time: {result.validation_time_seconds:.3f}s\n"
-        
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=response_text,
-                )
-            ]
-        )
-        
+            text += f"\nValidation time: {result.validation_time_seconds:.3f}s"
+        return _text_result(text)
+
     except ValidationError as e:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"Validation error: {str(e)}",
-                )
-            ]
-        )
-    except Exception as e:
-        logger.error(f"Unexpected error in validate_latex: {e}")
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"Unexpected error: {str(e)}",
-                )
-            ]
-        )
+        return _text_result(f"Validation error: {e}")
 
 
-async def handle_pdf_info(request: CallToolRequest) -> CallToolResult:
-    """Handle PDF info extraction requests."""
-    args = request.params.arguments or {}
-    
-    # Extract arguments
+async def _handle_pdf_info(args: dict) -> list[TextContent]:
     file_path = args.get("file_path")
-    include_text = args.get("include_text", False)
-    password = args.get("password")
-    
     if not file_path:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text="Error: file_path is required",
-                )
-            ]
-        )
-    
+        return _text_result("Error: file_path is required")
+
+    include_text = args.get("include_text", False)
     try:
-        # Run PDF info extraction in executor to avoid blocking
         loop = asyncio.get_event_loop()
         result = await loop.run_in_executor(
-            None,
-            extract_pdf_info,
-            file_path,
-            include_text,
-            password,
+            None, extract_pdf_info, file_path, include_text, args.get("password")
         )
-        
-        # Format response
+
         if result.success:
-            response_text = "✓ PDF info extracted successfully\n"
-            response_text += f"File: {result.file_path}\n"
-            response_text += f"Pages: {result.page_count}\n"
-            response_text += f"File size: {result.file_size_bytes:,} bytes\n"
-            
+            text = f"PDF info extracted\nFile: {result.file_path}"
+            text += f"\nPages: {result.page_count}"
+            text += f"\nFile size: {result.file_size_bytes:,} bytes"
             if result.pdf_version:
-                response_text += f"PDF version: {result.pdf_version}\n"
-            
-            if result.is_encrypted:
-                response_text += "Encrypted: Yes\n"
-            else:
-                response_text += "Encrypted: No\n"
-            
-            # Add page dimensions
+                text += f"\nPDF version: {result.pdf_version}"
+            text += f"\nEncrypted: {'Yes' if result.is_encrypted else 'No'}"
             if result.page_dimensions:
-                response_text += "Dimensions:\n"
+                text += "\nDimensions:"
                 for i, dims in enumerate(result.page_dimensions):
-                    response_text += f"  Page {i+1}: {dims['width']:.1f} x {dims['height']:.1f} {dims['unit']}\n"
-            
-            # Add metadata if available
-            if result.title:
-                response_text += f"Title: {result.title}\n"
-            if result.author:
-                response_text += f"Author: {result.author}\n"
-            if result.subject:
-                response_text += f"Subject: {result.subject}\n"
-            if result.producer:
-                response_text += f"Producer: {result.producer}\n"
-            if result.creator:
-                response_text += f"Creator: {result.creator}\n"
-            if result.creation_date:
-                response_text += f"Created: {result.creation_date}\n"
-            if result.modification_date:
-                response_text += f"Modified: {result.modification_date}\n"
-            
-            # Add text content if requested
+                    text += f"\n  Page {i + 1}: {dims['width']:.1f} x {dims['height']:.1f} {dims['unit']}"
+            for field, label in [
+                ("title", "Title"),
+                ("author", "Author"),
+                ("subject", "Subject"),
+                ("producer", "Producer"),
+                ("creator", "Creator"),
+                ("creation_date", "Created"),
+                ("modification_date", "Modified"),
+            ]:
+                val = getattr(result, field, None)
+                if val:
+                    text += f"\n{label}: {val}"
             if include_text and result.text_content:
-                response_text += "\nText content:\n"
-                for i, text in enumerate(result.text_content):
-                    if text.strip():  # Only show non-empty text
-                        response_text += f"  Page {i+1}: {text[:100]}...\n"
+                text += "\nText content:"
+                for i, page_text in enumerate(result.text_content):
+                    if page_text.strip():
+                        text += f"\n  Page {i + 1}: {page_text[:100]}..."
                     else:
-                        response_text += f"  Page {i+1}: [No text content]\n"
-            
-            # Add extraction time
+                        text += f"\n  Page {i + 1}: [No text content]"
             if result.extraction_time_seconds:
-                response_text += f"Extraction time: {result.extraction_time_seconds:.3f}s\n"
+                text += f"\nExtraction time: {result.extraction_time_seconds:.3f}s"
         else:
-            response_text = "✗ PDF info extraction failed\n"
+            text = "PDF info extraction failed"
             if result.error_message:
-                response_text += f"Error: {result.error_message}\n"
-            if result.extraction_time_seconds:
-                response_text += f"Extraction time: {result.extraction_time_seconds:.3f}s\n"
-        
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=response_text,
-                )
-            ]
-        )
-        
+                text += f"\nError: {result.error_message}"
+
+        return _text_result(text)
+
     except PDFInfoError as e:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"PDF info error: {str(e)}",
-                )
-            ]
-        )
-    except Exception as e:
-        logger.error(f"Unexpected error in pdf_info: {e}")
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"Unexpected error: {str(e)}",
-                )
-            ]
-        )
+        return _text_result(f"PDF info error: {e}")
 
 
-async def handle_cleanup(request: CallToolRequest) -> CallToolResult:
-    """Handle LaTeX cleanup requests."""
-    args = request.params.arguments or {}
-    
-    # Extract arguments
+async def _handle_cleanup(args: dict) -> list[TextContent]:
     path = args.get("path")
-    extensions = args.get("extensions")
-    dry_run = args.get("dry_run", False)
-    recursive = args.get("recursive", False)
-    create_backup = args.get("create_backup", False)
-    
     if not path:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text="Error: path is required",
-                )
-            ]
-        )
-    
+        return _text_result("Error: path is required")
+
     try:
-        # Run cleanup in executor to avoid blocking
         loop = asyncio.get_event_loop()
         result = await loop.run_in_executor(
             None,
             clean_latex,
             path,
-            extensions,
-            dry_run,
-            recursive,
-            create_backup,
+            args.get("extensions"),
+            args.get("dry_run", False),
+            args.get("recursive", False),
+            args.get("create_backup", False),
         )
-        
-        # Format response
+
         if result.success:
             if result.dry_run:
-                response_text = "✓ Cleanup dry run completed\n"
                 if result.would_clean_files:
-                    response_text += f"Would clean {len(result.would_clean_files)} files:\n"
-                    for file in result.would_clean_files[:10]:  # Show first 10
-                        response_text += f"  • {file}\n"
+                    text = f"Cleanup dry run: would clean {len(result.would_clean_files)} files:"
+                    for f in result.would_clean_files[:10]:
+                        text += f"\n  - {f}"
                     if len(result.would_clean_files) > 10:
-                        response_text += f"  ... and {len(result.would_clean_files) - 10} more\n"
+                        text += f"\n  ... and {len(result.would_clean_files) - 10} more"
                 else:
-                    response_text += "No files to clean\n"
+                    text = "Cleanup dry run: no files to clean"
             else:
-                response_text = "✓ Cleanup completed successfully\n"
                 if result.cleaned_files:
-                    response_text += f"Files cleaned: {result.cleaned_files_count}\n"
-                    for file in result.cleaned_files[:10]:  # Show first 10
-                        response_text += f"  • {file}\n"
+                    text = f"Cleanup completed: {result.cleaned_files_count} files cleaned:"
+                    for f in result.cleaned_files[:10]:
+                        text += f"\n  - {f}"
                     if len(result.cleaned_files) > 10:
-                        response_text += f"  ... and {len(result.cleaned_files) - 10} more\n"
+                        text += f"\n  ... and {len(result.cleaned_files) - 10} more"
                 else:
-                    response_text += "No files needed cleaning\n"
-            
-            # Add details about the operation
+                    text = "Cleanup completed: no files needed cleaning"
+
             if result.tex_file_path:
-                response_text += f"Cleaned around: {result.tex_file_path}\n"
+                text += f"\nCleaned around: {result.tex_file_path}"
             elif result.directory_path:
-                response_text += f"Cleaned directory: {result.directory_path}\n"
-            
+                text += f"\nCleaned directory: {result.directory_path}"
             if result.backup_created:
-                response_text += f"Backup created: {result.backup_directory}\n"
-            
+                text += f"\nBackup created: {result.backup_directory}"
             if result.cleanup_time_seconds:
-                response_text += f"Cleanup time: {result.cleanup_time_seconds:.3f}s\n"
+                text += f"\nCleanup time: {result.cleanup_time_seconds:.3f}s"
         else:
-            response_text = "✗ Cleanup failed\n"
+            text = "Cleanup failed"
             if result.error_message:
-                response_text += f"Error: {result.error_message}\n"
-        
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=response_text,
-                )
-            ]
-        )
-        
+                text += f"\nError: {result.error_message}"
+
+        return _text_result(text)
+
     except CleanupError as e:
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"Cleanup error: {str(e)}",
-                )
-            ]
-        )
-    except Exception as e:
-        logger.error(f"Unexpected error in cleanup: {e}")
-        return CallToolResult(
-            content=[
-                TextContent(
-                    type="text",
-                    text=f"Unexpected error: {str(e)}",
-                )
-            ]
-        )
+        return _text_result(f"Cleanup error: {e}")
 
 
 async def main():
     """Run the MCP server."""
     logger.info("Starting MCP LaTeX Tools server")
-    logger.debug(f"Server handlers: {list(server.request_handlers.keys())}")
-    
     async with stdio_server() as (read_stream, write_stream):
-        logger.debug("Got stdio streams, starting server.run()")
         await server.run(
             read_stream,
             write_stream,

--- a/src/mcp_latex_tools/server.py
+++ b/src/mcp_latex_tools/server.py
@@ -43,7 +43,7 @@ async def list_tools() -> list[Tool]:
     return [
         Tool(
             name="compile_latex",
-            description="Compile .tex to PDF via pdflatex. Creates .pdf/.aux/.log. Returns path, timing, errors.",
+            description="Compile .tex to PDF via pdflatex (requires pdflatex). Single-pass. Creates .pdf/.aux/.log. Returns path, timing, errors.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -126,7 +126,7 @@ async def list_tools() -> list[Tool]:
                     "extensions": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Custom extensions to clean (default: .aux, .log, .out, etc.)",
+                        "description": 'Extensions with leading dot (e.g., [".aux", ".log"]). Default: .aux, .log, .out, etc.',
                     },
                     "dry_run": {
                         "type": "boolean",
@@ -183,7 +183,8 @@ async def list_resources() -> list[Resource]:
 @server.read_resource()
 async def read_resource(uri: str) -> str:
     """Read resource content."""
-    if uri == "latex://config/cleanup-extensions":
+    uri_str = str(uri)
+    if uri_str == "latex://config/cleanup-extensions":
         return json.dumps(
             {
                 "extensions": sorted(DEFAULT_CLEANUP_EXTENSIONS),
@@ -193,7 +194,7 @@ async def read_resource(uri: str) -> str:
             indent=2,
         )
 
-    elif uri == "latex://config/protected-extensions":
+    elif uri_str == "latex://config/protected-extensions":
         return json.dumps(
             {
                 "extensions": sorted(PROTECTED_EXTENSIONS),
@@ -203,7 +204,7 @@ async def read_resource(uri: str) -> str:
             indent=2,
         )
 
-    elif uri == "latex://help/workflow":
+    elif uri_str == "latex://help/workflow":
         return """# LaTeX Compilation Workflow
 
 1. **Validate**: `validate_latex` — catch syntax errors fast
@@ -216,7 +217,7 @@ If compilation fails, run `validate_latex` to identify syntax errors.
 If validation passes but compilation fails, check for missing packages or increase timeout.
 """
 
-    raise ValueError(f"Unknown resource: {uri}")
+    raise ValueError(f"Unknown resource: {uri_str}")
 
 
 # =============================================================================
@@ -390,13 +391,23 @@ async def call_tool(tool_name: str, arguments: dict) -> list[TextContent]:  # ty
         return _text_result(f"Error: {e}")
 
 
+def _get_path_arg(args: dict, *keys: str) -> str | None:
+    """Get path argument, accepting common aliases."""
+    for key in keys:
+        if val := args.get(key):
+            return val
+    return None
+
+
 async def _handle_compile(args: dict) -> list[TextContent]:
-    tex_path = args.get("tex_path")
+    tex_path = _get_path_arg(args, "tex_path", "file_path", "path")
     if not tex_path:
-        return _text_result("Error: tex_path is required")
+        return _text_result(
+            "Error: tex_path is required. Pass the path to the .tex file."
+        )
 
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
             compile_latex,
@@ -424,12 +435,14 @@ async def _handle_compile(args: dict) -> list[TextContent]:
 
 
 async def _handle_validate(args: dict) -> list[TextContent]:
-    file_path = args.get("file_path")
+    file_path = _get_path_arg(args, "file_path", "tex_path", "path")
     if not file_path:
-        return _text_result("Error: file_path is required")
+        return _text_result(
+            "Error: file_path is required. Pass the path to the .tex file."
+        )
 
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
             validate_latex,
@@ -462,13 +475,15 @@ async def _handle_validate(args: dict) -> list[TextContent]:
 
 
 async def _handle_pdf_info(args: dict) -> list[TextContent]:
-    file_path = args.get("file_path")
+    file_path = _get_path_arg(args, "file_path", "path", "tex_path")
     if not file_path:
-        return _text_result("Error: file_path is required")
+        return _text_result(
+            "Error: file_path is required. Pass the path to the PDF file."
+        )
 
     include_text = args.get("include_text", False)
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None, extract_pdf_info, file_path, include_text, args.get("password")
         )
@@ -517,12 +532,14 @@ async def _handle_pdf_info(args: dict) -> list[TextContent]:
 
 
 async def _handle_cleanup(args: dict) -> list[TextContent]:
-    path = args.get("path")
+    path = _get_path_arg(args, "path", "file_path", "tex_path")
     if not path:
-        return _text_result("Error: path is required")
+        return _text_result(
+            "Error: path is required. Pass the path to a .tex file or directory."
+        )
 
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
             clean_latex,

--- a/src/mcp_latex_tools/utils/log_parser.py
+++ b/src/mcp_latex_tools/utils/log_parser.py
@@ -62,15 +62,13 @@ def parse_latex_log(log_content: str, max_errors: int = 10) -> LogSummary:
         if "warning" in line.lower():
             warnings_count += 1
 
-        # Count overfull/underfull hbox as warnings
-        if "overfull" in line.lower() or "underfull" in line.lower():
+        # Count overfull/underfull hbox as warnings (elif to avoid double-counting)
+        elif "overfull" in line.lower() or "underfull" in line.lower():
             warnings_count += 1
 
         # Check for undefined references
-        if (
-            "undefined references" in line.lower()
-            or "reference" in line.lower()
-            and "undefined" in line.lower()
+        if "undefined references" in line.lower() or (
+            "reference" in line.lower() and "undefined" in line.lower()
         ):
             has_undefined_references = True
 

--- a/tests/test_mcp_resources_prompts.py
+++ b/tests/test_mcp_resources_prompts.py
@@ -1,0 +1,254 @@
+"""Tests for MCP Resources and Prompts functionality."""
+
+import json
+import pytest
+
+from mcp_latex_tools.server import (
+    list_resources,
+    read_resource,
+    list_prompts,
+    get_prompt,
+)
+from mcp_latex_tools.tools.cleanup import (
+    DEFAULT_CLEANUP_EXTENSIONS as CLEANUP_EXTENSIONS,
+    PROTECTED_EXTENSIONS,
+)
+
+
+class TestMCPResources:
+    """Tests for MCP Resources functionality."""
+
+    @pytest.mark.asyncio
+    async def test_list_resources_returns_expected_resources(self):
+        """Test that list_resources returns all expected resources."""
+        resources = await list_resources()
+
+        assert len(resources) == 3
+
+        # Check resource URIs (convert to string for comparison)
+        uris = [str(r.uri) for r in resources]
+        assert "latex://config/cleanup-extensions" in uris
+        assert "latex://config/protected-extensions" in uris
+        assert "latex://help/workflow" in uris
+
+    @pytest.mark.asyncio
+    async def test_list_resources_has_correct_mime_types(self):
+        """Test that resources have correct MIME types."""
+        resources = await list_resources()
+
+        # Use string keys for the resource map
+        resource_map = {str(r.uri): r for r in resources}
+
+        assert (
+            resource_map["latex://config/cleanup-extensions"].mimeType
+            == "application/json"
+        )
+        assert (
+            resource_map["latex://config/protected-extensions"].mimeType
+            == "application/json"
+        )
+        assert resource_map["latex://help/workflow"].mimeType == "text/markdown"
+
+    @pytest.mark.asyncio
+    async def test_read_resource_cleanup_extensions(self):
+        """Test reading cleanup extensions resource."""
+        content = await read_resource("latex://config/cleanup-extensions")
+
+        data = json.loads(content)
+        assert "extensions" in data
+        assert "description" in data
+        assert "count" in data
+
+        # Verify all cleanup extensions are present
+        for ext in CLEANUP_EXTENSIONS:
+            assert ext in data["extensions"]
+
+        assert data["count"] == len(CLEANUP_EXTENSIONS)
+
+    @pytest.mark.asyncio
+    async def test_read_resource_protected_extensions(self):
+        """Test reading protected extensions resource."""
+        content = await read_resource("latex://config/protected-extensions")
+
+        data = json.loads(content)
+        assert "extensions" in data
+        assert "description" in data
+        assert "count" in data
+
+        # Verify all protected extensions are present
+        for ext in PROTECTED_EXTENSIONS:
+            assert ext in data["extensions"]
+
+        assert data["count"] == len(PROTECTED_EXTENSIONS)
+
+    @pytest.mark.asyncio
+    async def test_read_resource_workflow_guide(self):
+        """Test reading workflow guide resource."""
+        content = await read_resource("latex://help/workflow")
+
+        # Should be markdown content
+        assert "# LaTeX Compilation Workflow" in content
+        assert "validate_latex" in content
+        assert "compile_latex" in content
+        assert "pdf_info" in content
+        assert "cleanup" in content
+
+    @pytest.mark.asyncio
+    async def test_read_resource_unknown_uri_raises_error(self):
+        """Test that reading unknown resource raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown resource"):
+            await read_resource("latex://unknown/resource")
+
+
+class TestMCPPrompts:
+    """Tests for MCP Prompts functionality."""
+
+    @pytest.mark.asyncio
+    async def test_list_prompts_returns_expected_prompts(self):
+        """Test that list_prompts returns all expected prompts."""
+        prompts = await list_prompts()
+
+        assert len(prompts) == 3
+
+        # Check prompt names
+        names = [p.name for p in prompts]
+        assert "compile-and-verify" in names
+        assert "diagnose-compilation-error" in names
+        assert "prepare-fresh-build" in names
+
+    @pytest.mark.asyncio
+    async def test_list_prompts_have_descriptions(self):
+        """Test that all prompts have descriptions."""
+        prompts = await list_prompts()
+
+        for prompt in prompts:
+            assert prompt.description is not None
+            assert len(prompt.description) > 0
+
+    @pytest.mark.asyncio
+    async def test_list_prompts_have_required_arguments(self):
+        """Test that prompts have tex_path as required argument."""
+        prompts = await list_prompts()
+
+        for prompt in prompts:
+            # All prompts should have tex_path argument
+            arg_names = [arg.name for arg in prompt.arguments]
+            assert "tex_path" in arg_names
+
+            # tex_path should be required
+            tex_path_arg = next(
+                arg for arg in prompt.arguments if arg.name == "tex_path"
+            )
+            assert tex_path_arg.required is True
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_compile_and_verify(self):
+        """Test getting compile-and-verify prompt."""
+        result = await get_prompt("compile-and-verify", {"tex_path": "test.tex"})
+
+        assert result.description is not None
+        assert "test.tex" in result.description
+
+        # Check that messages contain workflow steps
+        assert len(result.messages) == 1
+        message_text = result.messages[0].content.text
+        assert "VALIDATE" in message_text
+        assert "COMPILE" in message_text
+        assert "VERIFY" in message_text
+        assert "test.tex" in message_text
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_compile_and_verify_with_cleanup_false(self):
+        """Test compile-and-verify prompt with cleanup disabled."""
+        result = await get_prompt(
+            "compile-and-verify", {"tex_path": "test.tex", "cleanup": "false"}
+        )
+
+        message_text = result.messages[0].content.text
+        assert "SKIP CLEANUP" in message_text
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_diagnose_compilation_error(self):
+        """Test getting diagnose-compilation-error prompt."""
+        result = await get_prompt(
+            "diagnose-compilation-error", {"tex_path": "broken.tex"}
+        )
+
+        assert result.description is not None
+        assert "broken.tex" in result.description
+
+        message_text = result.messages[0].content.text
+        assert "VALIDATE (Quick)" in message_text
+        assert "VALIDATE (Full)" in message_text
+        assert "VALIDATE (Strict)" in message_text
+        assert "DIAGNOSIS" in message_text
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_prepare_fresh_build(self):
+        """Test getting prepare-fresh-build prompt."""
+        result = await get_prompt("prepare-fresh-build", {"tex_path": "document.tex"})
+
+        assert result.description is not None
+        assert "document.tex" in result.description
+
+        message_text = result.messages[0].content.text
+        assert "PREVIEW CLEANUP" in message_text
+        assert "CLEAN" in message_text
+        assert "create_backup" in message_text
+        assert "COMPILE" in message_text
+        assert "VERIFY" in message_text
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_with_no_arguments(self):
+        """Test getting prompt with no arguments uses placeholder."""
+        result = await get_prompt("compile-and-verify", None)
+
+        message_text = result.messages[0].content.text
+        assert "<tex_path>" in message_text
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_unknown_name_raises_error(self):
+        """Test that getting unknown prompt raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown prompt"):
+            await get_prompt("unknown-prompt", {})
+
+
+class TestExtensionConstants:
+    """Tests for extension constant definitions."""
+
+    def test_cleanup_extensions_are_lowercase(self):
+        """Test that all cleanup extensions are lowercase."""
+        for ext in CLEANUP_EXTENSIONS:
+            assert ext == ext.lower()
+
+    def test_cleanup_extensions_start_with_dot(self):
+        """Test that all cleanup extensions start with a dot."""
+        for ext in CLEANUP_EXTENSIONS:
+            assert ext.startswith(".")
+
+    def test_protected_extensions_are_lowercase(self):
+        """Test that all protected extensions are lowercase."""
+        for ext in PROTECTED_EXTENSIONS:
+            assert ext == ext.lower()
+
+    def test_protected_extensions_start_with_dot(self):
+        """Test that all protected extensions start with a dot."""
+        for ext in PROTECTED_EXTENSIONS:
+            assert ext.startswith(".")
+
+    def test_no_overlap_between_cleanup_and_protected(self):
+        """Test that cleanup and protected extensions don't overlap."""
+        overlap = CLEANUP_EXTENSIONS & PROTECTED_EXTENSIONS
+        assert len(overlap) == 0, f"Extensions in both sets: {overlap}"
+
+    def test_tex_and_pdf_are_protected(self):
+        """Test that .tex and .pdf are in protected extensions."""
+        assert ".tex" in PROTECTED_EXTENSIONS
+        assert ".pdf" in PROTECTED_EXTENSIONS
+        assert ".bib" in PROTECTED_EXTENSIONS
+
+    def test_common_auxiliary_extensions_in_cleanup(self):
+        """Test that common auxiliary extensions are in cleanup set."""
+        common_aux = {".aux", ".log", ".out", ".toc", ".lof", ".lot"}
+        for ext in common_aux:
+            assert ext in CLEANUP_EXTENSIONS

--- a/tests/test_mcp_resources_prompts.py
+++ b/tests/test_mcp_resources_prompts.py
@@ -3,6 +3,7 @@
 import json
 import pytest
 
+from mcp.types import AnyUrl
 from mcp_latex_tools.server import (
     list_resources,
     read_resource,
@@ -92,6 +93,28 @@ class TestMCPResources:
         assert "compile_latex" in content
         assert "pdf_info" in content
         assert "cleanup" in content
+
+    @pytest.mark.asyncio
+    async def test_read_resource_with_anyurl_cleanup_extensions(self):
+        """Test that read_resource works with AnyUrl objects (MCP dispatch path)."""
+        content = await read_resource(AnyUrl("latex://config/cleanup-extensions"))
+        data = json.loads(content)
+        assert "extensions" in data
+        assert data["count"] == len(CLEANUP_EXTENSIONS)
+
+    @pytest.mark.asyncio
+    async def test_read_resource_with_anyurl_protected_extensions(self):
+        """Test that read_resource works with AnyUrl objects for protected extensions."""
+        content = await read_resource(AnyUrl("latex://config/protected-extensions"))
+        data = json.loads(content)
+        assert "extensions" in data
+        assert data["count"] == len(PROTECTED_EXTENSIONS)
+
+    @pytest.mark.asyncio
+    async def test_read_resource_with_anyurl_workflow(self):
+        """Test that read_resource works with AnyUrl objects for workflow guide."""
+        content = await read_resource(AnyUrl("latex://help/workflow"))
+        assert "# LaTeX Compilation Workflow" in content
 
     @pytest.mark.asyncio
     async def test_read_resource_unknown_uri_raises_error(self):

--- a/tests/test_server_error_handling.py
+++ b/tests/test_server_error_handling.py
@@ -2,539 +2,270 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from dataclasses import dataclass
+from typing import Optional
 
 import pytest
 
-from mcp_latex_tools.server import list_tools, handle_compile_latex, handle_validate_latex, handle_pdf_info, handle_cleanup, call_tool
-
-
-def create_mock_request(arguments: dict):
-    """Create a mock MCP request with proper structure."""
-    mock_params = type('MockParams', (), {
-        'arguments': arguments
-    })()
-    return type('MockRequest', (), {
-        'params': mock_params
-    })()
+from mcp_latex_tools.server import call_tool
 
 
 class TestServerErrorHandling:
     """Test server error handling paths and edge cases."""
-    
+
     @pytest.mark.asyncio
     async def test_call_tool_with_unknown_tool_name(self):
-        """Test call_tool with unknown tool name returns error result."""
-        mock_request = MagicMock()
-        mock_request.params.name = "unknown_tool"
-        mock_request.params.arguments = {}
-        
-        result = await call_tool(mock_request)
-        assert len(result.content) == 1
-        assert "Error: Unknown tool: unknown_tool" in result.content[0].text
-    
-    @pytest.mark.asyncio
-    async def test_call_tool_with_unexpected_exception(self):
-        """Test call_tool with unexpected exception in tool routing."""
-        mock_request = MagicMock()
-        mock_request.params.name = "compile_latex"
-        mock_request.params.arguments = {}
-        
-        # Mock handle_compile_latex to raise unexpected exception
-        with patch('mcp_latex_tools.server.handle_compile_latex', side_effect=RuntimeError("Unexpected error")):
-            result = await call_tool(mock_request)
-            assert len(result.content) == 1
-            assert "Error: Unexpected error" in result.content[0].text
-    
+        """Test call_tool with unknown tool name returns error."""
+        result = await call_tool("unknown_tool", {})
+        assert len(result) == 1
+        assert "Unknown tool: unknown_tool" in result[0].text
+
     @pytest.mark.asyncio
     async def test_compile_latex_with_unexpected_exception(self):
         """Test compile_latex handler with unexpected exception."""
-        # Create a temporary file to pass validation
-        with tempfile.NamedTemporaryFile(suffix='.tex', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".tex", delete=False) as tmp:
             tmp.write(b"\\documentclass{article}\\begin{document}test\\end{document}")
             tmp.flush()
-            
-            mock_request = create_mock_request({
-                "tex_path": tmp.name
-            })
-            
-            # Mock the compilation function to raise unexpected exception
-            with patch('mcp_latex_tools.tools.compile.compile_latex', side_effect=RuntimeError("Unexpected compile error")):
-                result = await handle_compile_latex(mock_request)
-                
-                assert result is not None
-                assert hasattr(result, 'content')
-                content = result.content[0]
-                assert hasattr(content, 'text')
-                assert "Unexpected error" in content.text
-    
+
+            with patch(
+                "mcp_latex_tools.server.compile_latex",
+                side_effect=RuntimeError("Unexpected compile error"),
+            ):
+                result = await call_tool("compile_latex", {"tex_path": tmp.name})
+                assert len(result) == 1
+                assert "Unexpected compile error" in result[0].text
+
+            Path(tmp.name).unlink()
+
     @pytest.mark.asyncio
     async def test_validate_latex_with_unexpected_exception(self):
         """Test validate_latex handler with unexpected exception."""
-        mock_request = create_mock_request({
-            "file_path": "test.tex"
-        })
-        
-        # Mock the validation function to raise unexpected exception
-        with patch('mcp_latex_tools.tools.validate.validate_latex', side_effect=RuntimeError("Unexpected validate error")):
-            result = await handle_validate_latex(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "Error during validation" in content.text
-            assert "Unexpected validate error" in content.text
-    
+        with patch(
+            "mcp_latex_tools.server.validate_latex",
+            side_effect=RuntimeError("Unexpected validate error"),
+        ):
+            result = await call_tool("validate_latex", {"file_path": "test.tex"})
+            assert len(result) == 1
+            assert "Unexpected validate error" in result[0].text
+
     @pytest.mark.asyncio
     async def test_pdf_info_with_unexpected_exception(self):
         """Test pdf_info handler with unexpected exception."""
-        mock_request = create_mock_request({
-            "pdf_path": "test.pdf"
-        })
-        
-        # Mock the PDF info function to raise unexpected exception
-        with patch('mcp_latex_tools.tools.pdf_info.extract_pdf_info', side_effect=RuntimeError("Unexpected PDF error")):
-            result = await handle_pdf_info(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "Error extracting PDF info" in content.text
-            assert "Unexpected PDF error" in content.text
-    
+        with patch(
+            "mcp_latex_tools.server.extract_pdf_info",
+            side_effect=RuntimeError("Unexpected PDF error"),
+        ):
+            result = await call_tool("pdf_info", {"file_path": "test.pdf"})
+            assert len(result) == 1
+            assert "Unexpected PDF error" in result[0].text
+
     @pytest.mark.asyncio
     async def test_cleanup_with_unexpected_exception(self):
         """Test cleanup handler with unexpected exception."""
-        mock_request = create_mock_request({
-            "path": "test.tex"
-        })
-        
-        # Mock the cleanup function to raise unexpected exception
-        with patch('mcp_latex_tools.tools.cleanup.clean_auxiliary_files', side_effect=RuntimeError("Unexpected cleanup error")):
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "Error during cleanup" in content.text
-            assert "Unexpected cleanup error" in content.text
+        with patch(
+            "mcp_latex_tools.server.clean_latex",
+            side_effect=RuntimeError("Unexpected cleanup error"),
+        ):
+            result = await call_tool("cleanup", {"path": "test.tex"})
+            assert len(result) == 1
+            assert "Unexpected cleanup error" in result[0].text
 
 
 class TestCompilationResponseFormatting:
     """Test compilation response formatting edge cases."""
-    
+
     @pytest.mark.asyncio
-    async def test_compilation_failure_with_timing_information(self):
-        """Test compilation failure response with timing information."""
-        mock_request = create_mock_request({
-            "tex_path": "test.tex"
-        })
-        
-        # Mock compilation result with failure but timing info
+    async def test_compilation_failure_with_timing(self):
+        """Test compilation failure response with timing info."""
+
         @dataclass
-        class MockCompilationResult:
-            success: bool
-            error_message: str
-            output_path: str = None
-            compilation_time_seconds: float = 1.5
-        
-        mock_result = MockCompilationResult(
-            success=False,
-            error_message="Compilation failed due to missing package",
-            compilation_time_seconds=1.5
-        )
-        
-        with patch('mcp_latex_tools.tools.compile.compile_latex', return_value=mock_result):
-            result = await handle_compile_latex(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✗ Compilation failed" in content.text
-            assert "missing package" in content.text
-            assert "Compilation time: 1.5s" in content.text
+        class MockResult:
+            success: bool = False
+            error_message: Optional[str] = "Compilation failed due to missing package"
+            output_path: Optional[str] = None
+            log_content: Optional[str] = None
+            compilation_time_seconds: Optional[float] = 1.5
+
+        with patch("mcp_latex_tools.server.compile_latex", return_value=MockResult()):
+            result = await call_tool("compile_latex", {"tex_path": "test.tex"})
+            text = result[0].text
+            assert "failed" in text.lower()
+            assert "missing package" in text
+            assert "1.5" in text
 
 
 class TestValidationResponseFormatting:
     """Test validation response formatting edge cases."""
-    
+
     @pytest.mark.asyncio
     async def test_validation_success_with_warnings(self):
         """Test validation success response with warnings."""
-        mock_request = create_mock_request({
-            "file_path": "test.tex"
-        })
-        
-        # Mock validation result with success but warnings
+
         @dataclass
-        class MockValidationResult:
-            is_valid: bool
-            warnings: list
-            error_message: str = None
-            validation_time_seconds: float = 0.5
-        
-        mock_result = MockValidationResult(
-            is_valid=True,
-            warnings=["Warning: Package geometry not found", "Warning: Missing bibliography"],
-            validation_time_seconds=0.5
-        )
-        
-        with patch('mcp_latex_tools.tools.validate.validate_latex', return_value=mock_result):
-            result = await handle_validate_latex(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Valid LaTeX syntax" in content.text
-            assert "Warnings:" in content.text
-            assert "Package geometry not found" in content.text
-            assert "Missing bibliography" in content.text
-    
+        class MockResult:
+            is_valid: bool = True
+            error_message: Optional[str] = None
+            errors: list = None  # type: ignore[assignment]
+            warnings: list = None  # type: ignore[assignment]
+            validation_time_seconds: Optional[float] = 0.5
+
+            def __post_init__(self):
+                if self.errors is None:
+                    self.errors = []
+                if self.warnings is None:
+                    self.warnings = [
+                        "Warning: Package geometry not found",
+                        "Warning: Missing bibliography",
+                    ]
+
+        with patch("mcp_latex_tools.server.validate_latex", return_value=MockResult()):
+            result = await call_tool("validate_latex", {"file_path": "test.tex"})
+            text = result[0].text
+            assert "Valid LaTeX syntax" in text
+            assert "Warnings" in text
+            assert "Package geometry not found" in text
+
     @pytest.mark.asyncio
-    async def test_validation_failure_with_warnings(self):
-        """Test validation failure response with warnings."""
-        mock_request = create_mock_request({
-            "file_path": "test.tex"
-        })
-        
-        # Mock validation result with failure and warnings
+    async def test_validation_failure_with_errors(self):
+        """Test validation failure response."""
+
         @dataclass
-        class MockValidationResult:
-            is_valid: bool
-            warnings: list
-            error_message: str
-            validation_time_seconds: float = 0.5
-        
-        mock_result = MockValidationResult(
-            is_valid=False,
-            warnings=["Warning: Deprecated command used"],
-            error_message="Syntax error: Missing closing brace",
-            validation_time_seconds=0.5
-        )
-        
-        with patch('mcp_latex_tools.tools.validate.validate_latex', return_value=mock_result):
-            result = await handle_validate_latex(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✗ Invalid LaTeX syntax" in content.text
-            assert "Warnings:" in content.text
-            assert "Deprecated command used" in content.text
-            assert "Missing closing brace" in content.text
+        class MockResult:
+            is_valid: bool = False
+            error_message: Optional[str] = "Syntax error"
+            errors: list = None  # type: ignore[assignment]
+            warnings: list = None  # type: ignore[assignment]
+            validation_time_seconds: Optional[float] = 0.5
+
+            def __post_init__(self):
+                if self.errors is None:
+                    self.errors = ["Missing closing brace"]
+                if self.warnings is None:
+                    self.warnings = ["Deprecated command used"]
+
+        with patch("mcp_latex_tools.server.validate_latex", return_value=MockResult()):
+            result = await call_tool("validate_latex", {"file_path": "test.tex"})
+            text = result[0].text
+            assert "Invalid LaTeX syntax" in text
+            assert "Missing closing brace" in text
+            assert "Deprecated command used" in text
 
 
 class TestPDFInfoResponseFormatting:
     """Test PDF info response formatting edge cases."""
-    
+
     @pytest.mark.asyncio
-    async def test_pdf_info_with_encrypted_pdf(self):
+    async def test_pdf_info_with_metadata(self):
+        """Test PDF info response with metadata fields."""
+
+        @dataclass
+        class MockResult:
+            success: bool = True
+            error_message: Optional[str] = None
+            file_path: str = "document.pdf"
+            file_size_bytes: int = 10000
+            page_count: int = 25
+            page_dimensions: list = None  # type: ignore[assignment]
+            pdf_version: Optional[str] = "1.7"
+            is_encrypted: bool = False
+            is_linearized: Optional[bool] = False
+            creation_date: Optional[str] = None
+            modification_date: Optional[str] = None
+            title: str = "LaTeX Document Title"
+            author: str = "John Doe"
+            subject: str = "Mathematics Research"
+            keywords: Optional[str] = None
+            producer: Optional[str] = None
+            creator: Optional[str] = None
+            text_content: Optional[list] = None
+            extraction_time_seconds: Optional[float] = 0.3
+
+            def __post_init__(self):
+                if self.page_dimensions is None:
+                    self.page_dimensions = [
+                        {"width": 612.0, "height": 792.0, "unit": "pt"}
+                    ]
+
+        with patch(
+            "mcp_latex_tools.server.extract_pdf_info", return_value=MockResult()
+        ):
+            result = await call_tool("pdf_info", {"file_path": "document.pdf"})
+            text = result[0].text
+            assert "PDF info extracted" in text
+            assert "Title: LaTeX Document Title" in text
+            assert "Author: John Doe" in text
+            assert "Pages: 25" in text
+
+    @pytest.mark.asyncio
+    async def test_pdf_info_encrypted(self):
         """Test PDF info response with encrypted PDF."""
-        mock_request = create_mock_request({
-            "pdf_path": "encrypted.pdf"
-        })
-        
-        # Mock PDF info result with encrypted flag
+
         @dataclass
-        class MockPDFInfo:
-            success: bool
-            pages: int
-            encrypted: bool = False
-            title: str = None
-            author: str = None
-            subject: str = None
-            extraction_time_seconds: float = 0.3
-        
-        mock_result = MockPDFInfo(
-            success=True,
-            pages=10,
-            encrypted=True,
-            extraction_time_seconds=0.3
-        )
-        
-        with patch('mcp_latex_tools.tools.pdf_info.extract_pdf_info', return_value=mock_result):
-            result = await handle_pdf_info(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ PDF info extracted successfully" in content.text
-            assert "Encrypted: Yes" in content.text
-            assert "Pages: 10" in content.text
-    
-    @pytest.mark.asyncio
-    async def test_pdf_info_with_all_metadata(self):
-        """Test PDF info response with all metadata fields."""
-        mock_request = create_mock_request({
-            "pdf_path": "document.pdf"
-        })
-        
-        # Mock PDF info result with all metadata
-        @dataclass
-        class MockPDFInfo:
-            success: bool
-            pages: int
-            encrypted: bool = False
-            title: str = None
-            author: str = None
-            subject: str = None
-            extraction_time_seconds: float = 0.3
-        
-        mock_result = MockPDFInfo(
-            success=True,
-            pages=25,
-            encrypted=False,
-            title="LaTeX Document Title",
-            author="John Doe",
-            subject="Mathematics Research",
-            extraction_time_seconds=0.3
-        )
-        
-        with patch('mcp_latex_tools.tools.pdf_info.extract_pdf_info', return_value=mock_result):
-            result = await handle_pdf_info(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ PDF info extracted successfully" in content.text
-            assert "Title: LaTeX Document Title" in content.text
-            assert "Author: John Doe" in content.text
-            assert "Subject: Mathematics Research" in content.text
-            assert "Pages: 25" in content.text
-    
-    @pytest.mark.asyncio
-    async def test_pdf_info_with_empty_page_content(self):
-        """Test PDF info response with pages that have no text content."""
-        mock_request = create_mock_request({
-            "pdf_path": "document.pdf",
-            "extract_text": True
-        })
-        
-        # Mock PDF info result with page text extraction
-        @dataclass
-        class MockPDFInfo:
-            success: bool
-            pages: int
-            page_texts: list
-            extraction_time_seconds: float = 0.5
-        
-        mock_result = MockPDFInfo(
-            success=True,
-            pages=3,
-            page_texts=["Page 1 content", "", "Page 3 content"],  # Page 2 is empty
-            extraction_time_seconds=0.5
-        )
-        
-        with patch('mcp_latex_tools.tools.pdf_info.extract_pdf_info', return_value=mock_result):
-            result = await handle_pdf_info(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ PDF info extracted successfully" in content.text
-            assert "Page 1: Page 1 content" in content.text
-            assert "Page 2: [No text content]" in content.text
-            assert "Page 3: Page 3 content" in content.text
+        class MockResult:
+            success: bool = True
+            error_message: Optional[str] = None
+            file_path: str = "encrypted.pdf"
+            file_size_bytes: int = 5000
+            page_count: int = 10
+            page_dimensions: list = None  # type: ignore[assignment]
+            pdf_version: Optional[str] = None
+            is_encrypted: bool = True
+            is_linearized: Optional[bool] = None
+            creation_date: Optional[str] = None
+            modification_date: Optional[str] = None
+            title: Optional[str] = None
+            author: Optional[str] = None
+            subject: Optional[str] = None
+            keywords: Optional[str] = None
+            producer: Optional[str] = None
+            creator: Optional[str] = None
+            text_content: Optional[list] = None
+            extraction_time_seconds: Optional[float] = 0.3
+
+            def __post_init__(self):
+                if self.page_dimensions is None:
+                    self.page_dimensions = []
+
+        with patch(
+            "mcp_latex_tools.server.extract_pdf_info", return_value=MockResult()
+        ):
+            result = await call_tool("pdf_info", {"file_path": "encrypted.pdf"})
+            text = result[0].text
+            assert "Encrypted: Yes" in text
+            assert "Pages: 10" in text
 
 
 class TestCleanupResponseFormatting:
     """Test cleanup response formatting edge cases."""
-    
-    @pytest.mark.asyncio
-    async def test_cleanup_dry_run_with_many_files(self):
-        """Test cleanup dry run response with more than 10 files."""
-        mock_request = create_mock_request({
-            "path": "test.tex",
-            "dry_run": True
-        })
-        
-        # Mock cleanup result with many files
-        @dataclass
-        class MockCleanupResult:
-            success: bool
-            dry_run: bool
-            files_to_clean: list
-            files_to_clean_count: int
-            cleanup_time_seconds: float = 0.2
-        
-        # Generate list of 15 files
-        many_files = [f"file{i}.aux" for i in range(15)]
-        
-        mock_result = MockCleanupResult(
-            success=True,
-            dry_run=True,
-            files_to_clean=many_files,
-            files_to_clean_count=15,
-            cleanup_time_seconds=0.2
-        )
-        
-        with patch('mcp_latex_tools.tools.cleanup.clean_auxiliary_files', return_value=mock_result):
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Cleanup dry run completed" in content.text
-            assert "Would clean 15 files" in content.text
-            assert "First 10 files:" in content.text
-            assert "file0.aux" in content.text
-            assert "file9.aux" in content.text
-            assert "... and 5 more files" in content.text
-    
-    @pytest.mark.asyncio
-    async def test_cleanup_with_many_files_cleaned(self):
-        """Test cleanup response with more than 10 files cleaned."""
-        mock_request = create_mock_request({
-            "path": "test.tex"
-        })
-        
-        # Mock cleanup result with many files cleaned
-        @dataclass
-        class MockCleanupResult:
-            success: bool
-            dry_run: bool
-            cleaned_files: list
-            cleaned_files_count: int
-            cleanup_time_seconds: float = 0.5
-        
-        # Generate list of 12 files
-        many_files = [f"document{i}.log" for i in range(12)]
-        
-        mock_result = MockCleanupResult(
-            success=True,
-            dry_run=False,
-            cleaned_files=many_files,
-            cleaned_files_count=12,
-            cleanup_time_seconds=0.5
-        )
-        
-        with patch('mcp_latex_tools.tools.cleanup.clean_auxiliary_files', return_value=mock_result):
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Cleanup completed successfully" in content.text
-            assert "Cleaned 12 files" in content.text
-            assert "First 10 files:" in content.text
-            assert "document0.log" in content.text
-            assert "document9.log" in content.text
-            assert "... and 2 more files" in content.text
-    
-    @pytest.mark.asyncio
-    async def test_cleanup_with_backup_created(self):
-        """Test cleanup response with backup directory created."""
-        mock_request = create_mock_request({
-            "path": "test.tex",
-            "create_backup": True
-        })
-        
-        # Mock cleanup result with backup
-        @dataclass
-        class MockCleanupResult:
-            success: bool
-            dry_run: bool
-            cleaned_files: list
-            cleaned_files_count: int
-            backup_directory: str
-            cleanup_time_seconds: float = 0.3
-        
-        mock_result = MockCleanupResult(
-            success=True,
-            dry_run=False,
-            cleaned_files=["test.aux", "test.log"],
-            cleaned_files_count=2,
-            backup_directory="/tmp/latex_backup_20231201_123456",
-            cleanup_time_seconds=0.3
-        )
-        
-        with patch('mcp_latex_tools.tools.cleanup.clean_auxiliary_files', return_value=mock_result):
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Cleanup completed successfully" in content.text
-            assert "Backup created: /tmp/latex_backup_20231201_123456" in content.text
-            assert "Cleaned 2 files" in content.text
-    
-    @pytest.mark.asyncio
-    async def test_cleanup_failure_with_error_message(self):
-        """Test cleanup failure response with error message."""
-        mock_request = create_mock_request({
-            "path": "test.tex"
-        })
-        
-        # Mock cleanup result with failure
-        @dataclass
-        class MockCleanupResult:
-            success: bool
-            error_message: str
-            cleanup_time_seconds: float = 0.1
-        
-        mock_result = MockCleanupResult(
-            success=False,
-            error_message="Permission denied: Cannot delete file test.aux",
-            cleanup_time_seconds=0.1
-        )
-        
-        with patch('mcp_latex_tools.tools.cleanup.clean_auxiliary_files', return_value=mock_result):
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✗ Cleanup failed" in content.text
-            assert "Permission denied: Cannot delete file test.aux" in content.text
-            assert "Cleanup time: 0.1s" in content.text
 
-
-class TestMainServerInitialization:
-    """Test main server initialization and entry point."""
-    
     @pytest.mark.asyncio
-    async def test_main_server_initialization(self):
-        """Test main server initialization function."""
-        # Mock the MCP server components
-        with patch('mcp_latex_tools.server.Server') as mock_server, \
-             patch('mcp_latex_tools.server.stdio_server') as mock_stdio:
-            
-            from mcp_latex_tools.server import main
-            
-            # Test that main function can be called
-            try:
-                await main()
-            except Exception:
-                # We expect some errors due to mocking, but function should be callable
-                pass
-            
-            # Verify server was created
-            mock_server.assert_called_once()
-    
-    def test_server_entry_point(self):
-        """Test server entry point execution."""
-        # Mock asyncio.run to avoid actual server startup
-        with patch('asyncio.run') as mock_run:
-            # Import and test the entry point
-            try:
-                import mcp_latex_tools.server
-                # The module should be importable
-                assert hasattr(mcp_latex_tools.server, 'main')
-                assert callable(mcp_latex_tools.server.main)
-            except Exception as e:
-                # If there are import issues, that's still a test case
-                assert "import" in str(e).lower() or "module" in str(e).lower()
+    async def test_cleanup_failure_with_error(self):
+        """Test cleanup failure response."""
+
+        @dataclass
+        class MockResult:
+            success: bool = False
+            error_message: str = "Permission denied"
+            tex_file_path: Optional[str] = None
+            directory_path: Optional[str] = None
+            cleaned_files_count: int = 0
+            cleaned_files: list = None  # type: ignore[assignment]
+            would_clean_files: list = None  # type: ignore[assignment]
+            dry_run: bool = False
+            recursive: bool = False
+            backup_created: bool = False
+            backup_directory: Optional[str] = None
+            cleanup_time_seconds: Optional[float] = 0.1
+
+            def __post_init__(self):
+                if self.cleaned_files is None:
+                    self.cleaned_files = []
+                if self.would_clean_files is None:
+                    self.would_clean_files = []
+
+        with patch("mcp_latex_tools.server.clean_latex", return_value=MockResult()):
+            result = await call_tool("cleanup", {"path": "test.tex"})
+            text = result[0].text
+            assert "failed" in text.lower()
+            assert "Permission denied" in text

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -2,21 +2,10 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
 
 import pytest
 
-from mcp_latex_tools.server import list_tools, handle_compile_latex, handle_validate_latex, handle_pdf_info, handle_cleanup, call_tool
-
-
-def create_mock_request(arguments: dict):
-    """Create a mock MCP request with proper structure."""
-    mock_params = type('MockParams', (), {
-        'arguments': arguments
-    })()
-    return type('MockRequest', (), {
-        'params': mock_params
-    })()
+from mcp_latex_tools.server import list_tools, call_tool
 
 
 class TestMCPServerIntegration:
@@ -25,45 +14,24 @@ class TestMCPServerIntegration:
     @pytest.mark.asyncio
     async def test_list_tools(self):
         """Test that the server can list available tools."""
-        # Call the list_tools handler directly
         result = await list_tools()
-        
+
         assert result is not None
-        assert hasattr(result, 'tools')
-        assert len(result.tools) == 4
-        
-        # Check compile_latex tool
-        compile_tool = next(t for t in result.tools if t.name == "compile_latex")
-        assert compile_tool.name == "compile_latex"
-        assert "LaTeX" in compile_tool.description
-        assert compile_tool.inputSchema is not None
-        assert "tex_path" in compile_tool.inputSchema["properties"]
-        
-        # Check validate_latex tool
-        validate_tool = next(t for t in result.tools if t.name == "validate_latex")
-        assert validate_tool.name == "validate_latex"
-        assert "validate" in validate_tool.description.lower()
-        assert validate_tool.inputSchema is not None
-        assert "file_path" in validate_tool.inputSchema["properties"]
-        
-        # Check pdf_info tool
-        pdf_info_tool = next(t for t in result.tools if t.name == "pdf_info")
-        assert pdf_info_tool.name == "pdf_info"
-        assert "pdf" in pdf_info_tool.description.lower()
-        assert pdf_info_tool.inputSchema is not None
-        assert "file_path" in pdf_info_tool.inputSchema["properties"]
-        
-        # Check cleanup tool
-        cleanup_tool = next(t for t in result.tools if t.name == "cleanup")
-        assert cleanup_tool.name == "cleanup"
-        assert "clean" in cleanup_tool.description.lower()
-        assert cleanup_tool.inputSchema is not None
-        assert "path" in cleanup_tool.inputSchema["properties"]
+        assert len(result) == 4
+
+        names = {t.name for t in result}
+        assert names == {"compile_latex", "validate_latex", "pdf_info", "cleanup"}
+
+        # Check tool schemas have required properties
+        tool_map = {t.name: t for t in result}
+        assert "tex_path" in tool_map["compile_latex"].inputSchema["properties"]
+        assert "file_path" in tool_map["validate_latex"].inputSchema["properties"]
+        assert "file_path" in tool_map["pdf_info"].inputSchema["properties"]
+        assert "path" in tool_map["cleanup"].inputSchema["properties"]
 
     @pytest.mark.asyncio
     async def test_compile_latex_tool_success(self):
         """Test successful LaTeX compilation through MCP tool."""
-        # Create a simple LaTeX document
         latex_content = r"""
 \documentclass{article}
 \begin{document}
@@ -76,38 +44,23 @@ This is a test document.
 
 \end{document}
 """
-        
-        # Create temporary file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.tex', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".tex", delete=False) as f:
             f.write(latex_content)
             tex_path = f.name
-        
+
         try:
-            # Create mock request arguments
-            mock_request = create_mock_request({
-                "tex_path": tex_path,
-                "timeout": 30
-            })
-            
-            # Call the tool handler directly
-            result = await handle_compile_latex(mock_request)
-            
+            result = await call_tool(
+                "compile_latex", {"tex_path": tex_path, "timeout": 30}
+            )
+
             assert result is not None
-            assert hasattr(result, 'content')
-            assert len(result.content) > 0
-            
-            # Check response content
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ LaTeX compilation successful!" in content.text
-            assert "Output:" in content.text
-            
+            assert len(result) > 0
+            assert "Compilation successful" in result[0].text
+            assert "Output:" in result[0].text
         finally:
-            # Cleanup
             try:
                 Path(tex_path).unlink()
-                # Find and remove PDF
-                pdf_path = Path(tex_path).with_suffix('.pdf')
+                pdf_path = Path(tex_path).with_suffix(".pdf")
                 if pdf_path.exists():
                     pdf_path.unlink()
             except Exception:
@@ -116,55 +69,22 @@ This is a test document.
     @pytest.mark.asyncio
     async def test_compile_latex_tool_missing_file(self):
         """Test LaTeX compilation with missing file."""
-        mock_request = create_mock_request({
-            "tex_path": "/nonexistent/file.tex"
-        })
-        
-        result = await handle_compile_latex(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "error" in content.text.lower()
+        result = await call_tool("compile_latex", {"tex_path": "/nonexistent/file.tex"})
+
+        assert len(result) > 0
+        assert "error" in result[0].text.lower()
 
     @pytest.mark.asyncio
     async def test_compile_latex_tool_missing_tex_path(self):
         """Test LaTeX compilation without required tex_path."""
-        mock_request = create_mock_request({})
-        
-        result = await handle_compile_latex(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "tex_path is required" in content.text
+        result = await call_tool("compile_latex", {})
 
-    @pytest.mark.asyncio
-    async def test_tex_path_validation(self):
-        """Test tex_path validation in tool handler."""
-        # Test with None arguments
-        mock_request = create_mock_request(None)
-        
-        result = await handle_compile_latex(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "tex_path is required" in content.text
+        assert len(result) > 0
+        assert "tex_path is required" in result[0].text
 
     @pytest.mark.asyncio
     async def test_validate_latex_tool_success(self):
         """Test successful LaTeX validation through MCP tool."""
-        # Create a simple valid LaTeX document
         latex_content = r"""
 \documentclass{article}
 \begin{document}
@@ -177,41 +97,25 @@ This is a valid test document.
 
 \end{document}
 """
-        
-        # Create temporary file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.tex', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".tex", delete=False) as f:
             f.write(latex_content)
             tex_path = f.name
-        
+
         try:
-            # Create mock request arguments
-            mock_request = create_mock_request({
-                "file_path": tex_path,
-                "quick": False,
-                "strict": False
-            })
-            
-            # Call the tool handler directly
-            result = await handle_validate_latex(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            assert len(result.content) > 0
-            
-            # Check response content
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Valid LaTeX syntax" in content.text
-            assert "No errors found" in content.text
-            
+            result = await call_tool(
+                "validate_latex",
+                {"file_path": tex_path, "quick": False, "strict": False},
+            )
+
+            assert len(result) > 0
+            assert "Valid LaTeX syntax" in result[0].text
+            assert "No errors found" in result[0].text
         finally:
-            # Cleanup
             Path(tex_path).unlink()
 
     @pytest.mark.asyncio
     async def test_validate_latex_tool_with_errors(self):
         """Test LaTeX validation with syntax errors."""
-        # Create LaTeX with syntax errors
         latex_content = r"""
 \documentclass{article}
 \begin{document}
@@ -224,340 +128,171 @@ E = mc^2
 
 \end{document}
 """
-        
-        # Create temporary file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.tex', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".tex", delete=False) as f:
             f.write(latex_content)
             tex_path = f.name
-        
+
         try:
-            mock_request = create_mock_request({
-                "file_path": tex_path
-            })
-            
-            result = await handle_validate_latex(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            assert len(result.content) > 0
-            
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✗ Invalid LaTeX syntax" in content.text
-            assert "Errors found" in content.text
-            
+            result = await call_tool("validate_latex", {"file_path": tex_path})
+
+            assert len(result) > 0
+            assert "Invalid LaTeX syntax" in result[0].text
+            assert "Errors found" in result[0].text
         finally:
             Path(tex_path).unlink()
 
-    @pytest.mark.asyncio 
+    @pytest.mark.asyncio
     async def test_validate_latex_tool_missing_file(self):
         """Test LaTeX validation with missing file."""
-        mock_request = create_mock_request({
-            "file_path": "/nonexistent/file.tex"
-        })
-        
-        result = await handle_validate_latex(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "error" in content.text.lower()
-        assert "not found" in content.text.lower()
+        result = await call_tool(
+            "validate_latex", {"file_path": "/nonexistent/file.tex"}
+        )
+
+        assert len(result) > 0
+        assert "error" in result[0].text.lower()
 
     @pytest.mark.asyncio
     async def test_validate_latex_tool_missing_file_path(self):
         """Test LaTeX validation without required file_path."""
-        mock_request = create_mock_request({})
-        
-        result = await handle_validate_latex(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "file_path is required" in content.text
+        result = await call_tool("validate_latex", {})
+
+        assert len(result) > 0
+        assert "file_path is required" in result[0].text
 
     @pytest.mark.asyncio
     async def test_validate_latex_tool_mutual_exclusivity(self):
         """Test that quick and strict modes are mutually exclusive."""
-        # Create temporary file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.tex', delete=False) as f:
-            f.write(r"""
-\documentclass{article}
-\begin{document}
-Test
-\end{document}
-""")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".tex", delete=False) as f:
+            f.write(r"\documentclass{article}\begin{document}Test\end{document}")
             tex_path = f.name
-        
+
         try:
-            mock_request = create_mock_request({
-                "file_path": tex_path,
-                "quick": True,
-                "strict": True
-            })
-            
-            result = await handle_validate_latex(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            assert len(result.content) > 0
-            
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "Cannot use both quick and strict modes simultaneously" in content.text
-            
+            result = await call_tool(
+                "validate_latex", {"file_path": tex_path, "quick": True, "strict": True}
+            )
+
+            assert len(result) > 0
+            assert "Cannot use both quick and strict" in result[0].text
         finally:
             Path(tex_path).unlink()
 
     @pytest.mark.asyncio
     async def test_pdf_info_tool_success(self):
         """Test successful PDF info extraction through MCP tool."""
-        # Use the simple.pdf fixture
         pdf_path = Path(__file__).parent / "fixtures" / "simple.pdf"
-        
-        mock_request = create_mock_request({
-            "file_path": str(pdf_path),
-            "include_text": False
-        })
-        
-        result = await handle_pdf_info(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "✓ PDF info extracted successfully" in content.text
-        assert "Pages:" in content.text
-        assert "File size:" in content.text
-        assert "Dimensions:" in content.text
+
+        result = await call_tool(
+            "pdf_info", {"file_path": str(pdf_path), "include_text": False}
+        )
+
+        assert len(result) > 0
+        assert "PDF info extracted" in result[0].text
+        assert "Pages:" in result[0].text
+        assert "File size:" in result[0].text
 
     @pytest.mark.asyncio
     async def test_pdf_info_tool_with_text_extraction(self):
         """Test PDF info extraction with text content."""
         pdf_path = Path(__file__).parent / "fixtures" / "simple.pdf"
-        
-        mock_request = create_mock_request({
-            "file_path": str(pdf_path),
-            "include_text": True
-        })
-        
-        result = await handle_pdf_info(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "✓ PDF info extracted successfully" in content.text
-        assert "Text content:" in content.text
+
+        result = await call_tool(
+            "pdf_info", {"file_path": str(pdf_path), "include_text": True}
+        )
+
+        assert len(result) > 0
+        assert "PDF info extracted" in result[0].text
+        assert "Text content:" in result[0].text
 
     @pytest.mark.asyncio
     async def test_pdf_info_tool_missing_file(self):
         """Test PDF info extraction with missing file."""
-        mock_request = create_mock_request({
-            "file_path": "/nonexistent/file.pdf"
-        })
-        
-        result = await handle_pdf_info(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "error" in content.text.lower()
-        assert "not found" in content.text.lower()
+        result = await call_tool("pdf_info", {"file_path": "/nonexistent/file.pdf"})
+
+        assert len(result) > 0
+        assert "error" in result[0].text.lower()
 
     @pytest.mark.asyncio
     async def test_pdf_info_tool_missing_file_path(self):
         """Test PDF info extraction without required file_path."""
-        mock_request = create_mock_request({})
-        
-        result = await handle_pdf_info(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "file_path is required" in content.text
+        result = await call_tool("pdf_info", {})
 
-    @pytest.mark.asyncio
-    async def test_pdf_info_tool_invalid_pdf_file(self):
-        """Test PDF info extraction with invalid PDF file."""
-        # Use a non-PDF file
-        tex_path = Path(__file__).parent / "fixtures" / "simple.tex"
-        
-        mock_request = create_mock_request({
-            "file_path": str(tex_path)
-        })
-        
-        result = await handle_pdf_info(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "✗ PDF info extraction failed" in content.text or "invalid" in content.text.lower()
+        assert len(result) > 0
+        assert "file_path is required" in result[0].text
 
     @pytest.mark.asyncio
     async def test_cleanup_tool_success(self):
         """Test successful cleanup through MCP tool."""
-        # Create temporary directory with auxiliary files
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            
-            # Create .tex file
             tex_file = temp_path / "test.tex"
-            tex_file.write_text(r"\documentclass{article}\begin{document}Test\end{document}")
-            
-            # Create auxiliary files
-            aux_files = [
-                temp_path / "test.aux",
-                temp_path / "test.log",
-                temp_path / "test.out",
-            ]
-            
-            for aux_file in aux_files:
-                aux_file.write_text("auxiliary content")
-            
-            mock_request = create_mock_request({
-                "path": str(tex_file),
-                "dry_run": False
-            })
-            
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            assert len(result.content) > 0
-            
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Cleanup completed successfully" in content.text
-            assert "Files cleaned:" in content.text
+            tex_file.write_text(
+                r"\documentclass{article}\begin{document}Test\end{document}"
+            )
+
+            for ext in [".aux", ".log", ".out"]:
+                (temp_path / f"test{ext}").write_text("auxiliary content")
+
+            result = await call_tool(
+                "cleanup", {"path": str(tex_file), "dry_run": False}
+            )
+
+            assert len(result) > 0
+            assert "Cleanup completed" in result[0].text
+            assert "files cleaned" in result[0].text
 
     @pytest.mark.asyncio
     async def test_cleanup_tool_dry_run(self):
         """Test cleanup dry run through MCP tool."""
-        # Create temporary directory with auxiliary files
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            
-            # Create .tex file
             tex_file = temp_path / "dryrun.tex"
-            tex_file.write_text(r"\documentclass{article}\begin{document}Test\end{document}")
-            
-            # Create auxiliary files
-            aux_files = [
-                temp_path / "dryrun.aux",
-                temp_path / "dryrun.log",
-            ]
-            
-            for aux_file in aux_files:
-                aux_file.write_text("auxiliary content")
-            
-            mock_request = create_mock_request({
-                "path": str(tex_file),
-                "dry_run": True
-            })
-            
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            assert len(result.content) > 0
-            
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Cleanup dry run completed" in content.text
-            assert "Would clean" in content.text
+            tex_file.write_text(
+                r"\documentclass{article}\begin{document}Test\end{document}"
+            )
+
+            for ext in [".aux", ".log"]:
+                (temp_path / f"dryrun{ext}").write_text("auxiliary content")
+
+            result = await call_tool(
+                "cleanup", {"path": str(tex_file), "dry_run": True}
+            )
+
+            assert len(result) > 0
+            assert "dry run" in result[0].text.lower()
+            assert "would clean" in result[0].text.lower()
 
     @pytest.mark.asyncio
     async def test_cleanup_tool_missing_path(self):
         """Test cleanup without required path."""
-        mock_request = create_mock_request({})
-        
-        result = await handle_cleanup(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "path is required" in content.text
+        result = await call_tool("cleanup", {})
+
+        assert len(result) > 0
+        assert "path is required" in result[0].text
 
     @pytest.mark.asyncio
     async def test_cleanup_tool_nonexistent_path(self):
         """Test cleanup with non-existent path."""
-        mock_request = create_mock_request({
-            "path": "/nonexistent/file.tex"
-        })
-        
-        result = await handle_cleanup(mock_request)
-        
-        assert result is not None
-        assert hasattr(result, 'content')
-        assert len(result.content) > 0
-        
-        content = result.content[0]
-        assert hasattr(content, 'text')
-        assert "error" in content.text.lower()
-        assert "not found" in content.text.lower()
+        result = await call_tool("cleanup", {"path": "/nonexistent/file.tex"})
+
+        assert len(result) > 0
+        assert "error" in result[0].text.lower()
 
     @pytest.mark.asyncio
     async def test_cleanup_tool_directory_cleanup(self):
         """Test cleanup of entire directory through MCP tool."""
-        # Create temporary directory with multiple files
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            
-            # Create multiple .tex files
-            tex_files = [
-                temp_path / "doc1.tex",
-                temp_path / "doc2.tex",
-            ]
-            
-            for tex_file in tex_files:
-                tex_file.write_text(r"\documentclass{article}\begin{document}Test\end{document}")
-            
-            # Create auxiliary files
-            aux_files = [
-                temp_path / "doc1.aux",
-                temp_path / "doc1.log",
-                temp_path / "doc2.aux",
-                temp_path / "doc2.log",
-            ]
-            
-            for aux_file in aux_files:
-                aux_file.write_text("auxiliary content")
-            
-            mock_request = create_mock_request({
-                "path": str(temp_path),
-                "recursive": True
-            })
-            
-            result = await handle_cleanup(mock_request)
-            
-            assert result is not None
-            assert hasattr(result, 'content')
-            assert len(result.content) > 0
-            
-            content = result.content[0]
-            assert hasattr(content, 'text')
-            assert "✓ Cleanup completed successfully" in content.text
-            assert "Files cleaned:" in content.text
+
+            for name in ["doc1", "doc2"]:
+                (temp_path / f"{name}.tex").write_text(
+                    r"\documentclass{article}\begin{document}Test\end{document}"
+                )
+                for ext in [".aux", ".log"]:
+                    (temp_path / f"{name}{ext}").write_text("auxiliary content")
+
+            result = await call_tool(
+                "cleanup", {"path": str(temp_path), "recursive": True}
+            )
+
+            assert len(result) > 0
+            assert "Cleanup completed" in result[0].text


### PR DESCRIPTION
## Summary
- **Tool descriptions**: ~74% token reduction — compress verbose multi-line `USE THIS TOOL WHEN`/`CAPABILITIES`/`WORKFLOW` blocks into single-line descriptions (~383 total chars)
- **Handler refactor**: Remove `CallToolRequest` wrapper indirection (4x ~100-line `handle_*` functions → 4x ~30-line `_handle_*` functions)
- **Remove `format_structured_response()`**: Was double-encoding JSON in HTML comments — MCP already returns structured data
- **Import constants from cleanup.py** instead of duplicating (consolidation from PR #5)
- **Logging**: Change default from DEBUG to WARNING, remove trivial debug statements
- **server.py**: 954 → 587 lines (-38%)

## Test plan
- [x] All 169 tests pass (94% coverage)
- [x] mypy clean
- [x] ruff clean  
- [x] Server starts without crash
- [x] All 4 tools return concise descriptions
- [x] Rewrote test_server_integration.py and test_server_error_handling.py for new API
- [x] Added test_mcp_resources_prompts.py for resources/prompts coverage

> **Stack**: PR 3 of 4 — merge after PR #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)