### PR TITLE
[26Q2-REFAC-01] Pydantic Migration Part 1

### DIFF
--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MCP LaTeX Tools Architecture Documentation
 
-**Last Updated**: 2026-04-05
+**Last Updated**: 2026-04-06
 **Version**: 2.0
 
 ## Table of Contents
@@ -139,13 +139,24 @@ Each tool follows a consistent schema pattern:
 
 ## Tool Design Patterns
 
-### Pattern 1: Result Dataclasses
+### Pattern 1: Result Models
 
-Each tool returns a structured result:
+Each tool returns a structured result model. Models are being migrated from `dataclasses` to Pydantic `BaseModel` for automatic validation, JSON schema generation, and richer serialization.
+
+**Migration Status**:
+
+| Model | Module | Status |
+|-------|--------|--------|
+| `LaTeXError` | `utils/log_parser.py` | Pydantic BaseModel |
+| `LogSummary` | `utils/log_parser.py` | Pydantic BaseModel |
+| `ValidationResult` | `tools/validate.py` | Pydantic BaseModel |
+| `CompilationResult` | `tools/compile.py` | dataclass (pending) |
+| `PackageDetectionResult` | `tools/detect_packages.py` | dataclass (pending) |
+| `CleanupResult` | `tools/cleanup.py` | dataclass (pending) |
+| `PDFInfoResult` | `tools/pdf_info.py` | dataclass (pending) |
 
 ```python
-@dataclass
-class CompilationResult:
+class CompilationResult(BaseModel):
     success: bool
     output_path: Optional[str] = None
     error_message: Optional[str] = None
@@ -158,6 +169,8 @@ class CompilationResult:
 - Clear success/failure states
 - Comprehensive error information
 - Performance metrics included
+- Automatic input validation (Pydantic models)
+- JSON schema generation for MCP (Pydantic models)
 
 ### Pattern 2: Graceful Error Handling
 
@@ -246,6 +259,7 @@ See [BACKLOG.md](BACKLOG.md) for the full feature backlog and prioritization.
 
 ### Key Technologies
 - **MCP**: Model Context Protocol for Claude Code integration
+- **Pydantic**: Data validation and serialization (transitive via mcp)
 - **pypdf**: PDF metadata extraction
 - **pytest**: Testing framework with async support
 - **ruff**: Modern Python linter and formatter
@@ -260,5 +274,6 @@ See [BACKLOG.md](BACKLOG.md) for the full feature backlog and prioritization.
 ---
 
 **Document Version History**:
+- 2026-04-06: Added Pydantic migration status table (26Q2-REFAC-01)
 - 2026-04-05: Major rewrite — updated for post-cleanup architecture
 - 2025-10-22: Initial architecture document

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -156,11 +156,21 @@ Each tool returns a structured result model. Models are being migrated from `dat
 | `PDFInfoResult` | `tools/pdf_info.py` | dataclass (pending) |
 
 ```python
-class CompilationResult(BaseModel):
+# Already migrated (Part 1)
+class ValidationResult(BaseModel):
+    is_valid: bool
+    error_message: Optional[str]
+    errors: list[str]
+    warnings: list[str]
+    validation_time_seconds: Optional[float] = None
+
+# Pending migration (Parts 2-3)
+@dataclass
+class CompilationResult:
     success: bool
     output_path: Optional[str] = None
     error_message: Optional[str] = None
-    log_content: Optional[str] = None  # Full log for internal use
+    log_content: Optional[str] = None
     compilation_time_seconds: Optional[float] = None
 ```
 

--- a/docs/tasks/26Q2-REFAC-01.md
+++ b/docs/tasks/26Q2-REFAC-01.md
@@ -1,0 +1,204 @@
+### 26Q2-REFAC-01: Pydantic Migration Part 1 — Utility and Validation Models
+
+**User Story**: As a developer of mcp-latex-tools, I want to migrate dataclasses to Pydantic models so that I get automatic validation, richer serialization, and JSON schema generation for MCP tool results.
+
+| Field | Value |
+|-------|-------|
+| **Story Points** | 3 |
+| **Priority** | HIGH |
+| **Status** | 🔲 PENDING |
+| **Branch** | `26Q2-REFAC-01-pydantic-migration-p1` |
+| **Dependencies** | None |
+| **PR Size Target** | ~300-400 lines |
+
+---
+
+#### Context
+
+**Current State**:
+- 7 dataclass result classes across 6 source files, all using `from dataclasses import dataclass`
+- This is Part 1 of 3: migrates `LaTeXError`, `LogSummary` (log_parser.py) and `ValidationResult` (validate.py) — the 3 smallest classes (4-6 fields each)
+- Pydantic 2.11.7 is already available as a transitive dependency of `mcp>=1.11.0` — no new dependency needed
+- 226 tests currently passing across the full suite
+- All result classes are consumed via attribute access (dot notation) — Pydantic BaseModel preserves this interface
+- No existing JSON schema automation; schemas in `docs/schemas/mcp-tools.json` are manually written
+
+**Investigation**:
+```bash
+$ uv run python -c "import pydantic; print(pydantic.__version__)"
+2.11.7
+
+$ grep -n "from dataclasses import dataclass" src/mcp_latex_tools/utils/log_parser.py
+4:from dataclasses import dataclass
+
+$ grep -n "from dataclasses import dataclass" src/mcp_latex_tools/tools/validate.py
+5:from dataclasses import dataclass
+
+$ grep -c "LaTeXError\|LogSummary" tests/test_log_parser.py
+13
+
+$ grep -c "ValidationResult" tests/test_validate.py
+8
+
+$ uv run pytest --co -q | tail -1
+226 tests collected in 0.49s
+```
+
+---
+
+#### Acceptance Criteria
+
+**log_parser.py — LaTeXError Migration**:
+- [ ] `LaTeXError` is a `pydantic.BaseModel` (not a dataclass)
+- [ ] Fields preserved: `line_number: Optional[int]`, `error_type: str`, `message: str`, `context: Optional[str] = None`
+- [ ] `from dataclasses import dataclass` removed from log_parser.py
+- [ ] `from pydantic import BaseModel` present in log_parser.py
+- [ ] `LaTeXError` instances are still created with keyword arguments throughout codebase
+- [ ] `LaTeXError` fields accessible via dot notation (unchanged API)
+
+**log_parser.py — LogSummary Migration**:
+- [ ] `LogSummary` is a `pydantic.BaseModel` (not a dataclass)
+- [ ] Fields preserved: `errors: List[LaTeXError]`, `warnings_count: int`, `pages_count: Optional[int] = None`, `has_undefined_references: bool = False`, `has_rerun_suggestion: bool = False`
+- [ ] `LogSummary` instances are still created with keyword arguments throughout codebase
+- [ ] `LogSummary.errors` validates that elements are `LaTeXError` instances
+
+**validate.py — ValidationResult Migration**:
+- [ ] `ValidationResult` is a `pydantic.BaseModel` (not a dataclass)
+- [ ] Fields preserved: `is_valid: bool`, `error_message: Optional[str]`, `errors: list[str]`, `warnings: list[str]`, `validation_time_seconds: Optional[float] = None`
+- [ ] `from dataclasses import dataclass` removed from validate.py
+- [ ] `from pydantic import BaseModel` present in validate.py
+- [ ] `ValidationResult` instances are still created with keyword arguments throughout codebase
+- [ ] `ValidationResult` fields accessible via dot notation (unchanged API)
+
+**Backwards Compatibility**:
+- [ ] All 226 existing tests pass without modification (tests are immutable)
+- [ ] `server.py` handlers for `validate` and `compile` (which uses log parser) work unchanged
+- [ ] No changes to function signatures of `parse_latex_log()`, `validate_latex()`, or any public API
+- [ ] Other dataclass-based result classes (`CompilationResult`, `CleanupResult`, `PDFInfoResult`, `PackageDetectionResult`) remain as dataclasses (unchanged)
+
+**Tests**:
+- [ ] All existing tests in `tests/test_log_parser.py` pass (18 tests)
+- [ ] All existing tests in `tests/test_validate.py` pass (11 tests)
+- [ ] Full test suite passes: `uv run pytest`
+- [ ] Type checking passes: `uv run mypy src/`
+- [ ] Lint passes: `uv run ruff check src/ tests/`
+- [ ] Format passes: `uv run ruff format --check src/ tests/`
+
+**Documentation**:
+- [ ] `docs/development/ARCHITECTURE.md` notes Pydantic migration status (which classes migrated, which remain)
+
+---
+
+#### Files to Create/Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/mcp_latex_tools/utils/log_parser.py` | MODIFY | Migrate `LaTeXError` and `LogSummary` from dataclass to BaseModel |
+| `src/mcp_latex_tools/tools/validate.py` | MODIFY | Migrate `ValidationResult` from dataclass to BaseModel |
+| `docs/development/ARCHITECTURE.md` | MODIFY | Note Pydantic migration progress |
+
+---
+
+#### Implementation Notes
+
+- **Drop-in replacement**: Pydantic `BaseModel` supports the same keyword-argument construction and dot-notation access as dataclasses — the migration should be transparent to all consumers
+- **Import swap**: Replace `from dataclasses import dataclass` with `from pydantic import BaseModel`, and change `@dataclass` class decorator to `class Foo(BaseModel):`
+- **No `@dataclass` decorator**: Pydantic models use class inheritance, not decorators
+- **Frozen models**: Consider `model_config = ConfigDict(frozen=True)` to preserve the immutability that dataclasses had by default — but only if existing code doesn't mutate result fields (investigation shows no mutation)
+- **Type compatibility**: Pydantic 2.x with `List[X]` and `Optional[X]` types works identically to dataclass field annotations
+- **Do NOT add pydantic to pyproject.toml dependencies** — it's already available transitively via `mcp>=1.11.0`. Adding it explicitly is a decision for a later task if desired.
+- **Existing tests must pass unchanged** — this is a refactoring, not a behavior change
+
+---
+
+#### Verification Script
+
+```bash
+#!/bin/bash
+set -e
+
+echo "=== 26Q2-REFAC-01 Verification ==="
+
+# 1. LaTeXError is a Pydantic BaseModel
+uv run python -c "
+from mcp_latex_tools.utils.log_parser import LaTeXError
+from pydantic import BaseModel
+assert issubclass(LaTeXError, BaseModel), 'LaTeXError is not a BaseModel'
+e = LaTeXError(line_number=42, error_type='LaTeX Error', message='test')
+assert e.line_number == 42
+assert e.context is None
+print('LaTeXError OK')
+"
+
+# 2. LogSummary is a Pydantic BaseModel
+uv run python -c "
+from mcp_latex_tools.utils.log_parser import LogSummary, LaTeXError
+from pydantic import BaseModel
+assert issubclass(LogSummary, BaseModel), 'LogSummary is not a BaseModel'
+s = LogSummary(errors=[], warnings_count=0)
+assert s.pages_count is None
+assert s.has_undefined_references is False
+assert s.has_rerun_suggestion is False
+print('LogSummary OK')
+"
+
+# 3. ValidationResult is a Pydantic BaseModel
+uv run python -c "
+from mcp_latex_tools.tools.validate import ValidationResult
+from pydantic import BaseModel
+assert issubclass(ValidationResult, BaseModel), 'ValidationResult is not a BaseModel'
+r = ValidationResult(is_valid=True, error_message=None, errors=[], warnings=[])
+assert r.validation_time_seconds is None
+print('ValidationResult OK')
+"
+
+# 4. No dataclass imports in migrated files
+! grep -q "from dataclasses import dataclass" src/mcp_latex_tools/utils/log_parser.py
+echo "log_parser.py: no dataclass import OK"
+! grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/validate.py
+echo "validate.py: no dataclass import OK"
+
+# 5. Pydantic import present in migrated files
+grep -q "from pydantic import BaseModel" src/mcp_latex_tools/utils/log_parser.py
+grep -q "from pydantic import BaseModel" src/mcp_latex_tools/tools/validate.py
+echo "Pydantic imports OK"
+
+# 6. Other result classes still use dataclasses (not yet migrated)
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/compile.py
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/cleanup.py
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/pdf_info.py
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/detect_packages.py
+echo "Non-migrated classes still dataclasses OK"
+
+# 7. Log parser tests pass
+uv run pytest tests/test_log_parser.py -v --tb=short
+
+# 8. Validate tests pass
+uv run pytest tests/test_validate.py -v --tb=short
+
+# 9. Full suite passes (no regressions)
+uv run pytest --tb=short -q
+
+# 10. Code quality
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+
+# 11. Docs updated
+grep -q "Pydantic" docs/development/ARCHITECTURE.md
+echo "Docs OK"
+
+echo ""
+echo "=== All 26Q2-REFAC-01 verification checks passed ==="
+```
+
+---
+
+#### Definition of Done
+
+- [ ] All acceptance criteria checked off
+- [ ] Verification script exits with code 0
+- [ ] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
+- [ ] PR created with <500 lines changed
+- [ ] All 226+ existing tests pass unchanged
+- [ ] Documentation updated (ARCHITECTURE.md)

--- a/docs/tasks/verify-26Q2-REFAC-01.sh
+++ b/docs/tasks/verify-26Q2-REFAC-01.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+echo "=== 26Q2-REFAC-01 Verification ==="
+
+# 1. LaTeXError is a Pydantic BaseModel
+uv run python -c "
+from mcp_latex_tools.utils.log_parser import LaTeXError
+from pydantic import BaseModel
+assert issubclass(LaTeXError, BaseModel), 'LaTeXError is not a BaseModel'
+e = LaTeXError(line_number=42, error_type='LaTeX Error', message='test')
+assert e.line_number == 42
+assert e.context is None
+print('LaTeXError OK')
+"
+
+# 2. LogSummary is a Pydantic BaseModel
+uv run python -c "
+from mcp_latex_tools.utils.log_parser import LogSummary, LaTeXError
+from pydantic import BaseModel
+assert issubclass(LogSummary, BaseModel), 'LogSummary is not a BaseModel'
+s = LogSummary(errors=[], warnings_count=0)
+assert s.pages_count is None
+assert s.has_undefined_references is False
+assert s.has_rerun_suggestion is False
+print('LogSummary OK')
+"
+
+# 3. ValidationResult is a Pydantic BaseModel
+uv run python -c "
+from mcp_latex_tools.tools.validate import ValidationResult
+from pydantic import BaseModel
+assert issubclass(ValidationResult, BaseModel), 'ValidationResult is not a BaseModel'
+r = ValidationResult(is_valid=True, error_message=None, errors=[], warnings=[])
+assert r.validation_time_seconds is None
+print('ValidationResult OK')
+"
+
+# 4. No dataclass imports in migrated files
+! grep -q "from dataclasses import dataclass" src/mcp_latex_tools/utils/log_parser.py
+echo "log_parser.py: no dataclass import OK"
+! grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/validate.py
+echo "validate.py: no dataclass import OK"
+
+# 5. Pydantic import present in migrated files
+grep -q "from pydantic import BaseModel" src/mcp_latex_tools/utils/log_parser.py
+grep -q "from pydantic import BaseModel" src/mcp_latex_tools/tools/validate.py
+echo "Pydantic imports OK"
+
+# 6. Other result classes still use dataclasses (not yet migrated)
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/compile.py
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/cleanup.py
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/pdf_info.py
+grep -q "from dataclasses import dataclass" src/mcp_latex_tools/tools/detect_packages.py
+echo "Non-migrated classes still dataclasses OK"
+
+# 7. Log parser tests pass
+uv run pytest tests/test_log_parser.py -v --tb=short
+
+# 8. Validate tests pass
+uv run pytest tests/test_validate.py -v --tb=short
+
+# 9. Full suite passes (no regressions)
+uv run pytest --tb=short -q
+
+# 10. Code quality
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+
+# 11. Docs updated
+grep -q "Pydantic" docs/development/ARCHITECTURE.md
+echo "Docs OK"
+
+echo ""
+echo "=== All 26Q2-REFAC-01 verification checks passed ==="

--- a/src/mcp_latex_tools/tools/validate.py
+++ b/src/mcp_latex_tools/tools/validate.py
@@ -2,9 +2,10 @@
 
 import re
 import time
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+from pydantic import BaseModel
 
 
 class ValidationError(Exception):
@@ -13,8 +14,7 @@ class ValidationError(Exception):
     pass
 
 
-@dataclass
-class ValidationResult:
+class ValidationResult(BaseModel):
     """Result of LaTeX validation."""
 
     is_valid: bool

--- a/src/mcp_latex_tools/utils/log_parser.py
+++ b/src/mcp_latex_tools/utils/log_parser.py
@@ -1,12 +1,12 @@
 """LaTeX log parsing utilities for extracting concise error information."""
 
 import re
-from dataclasses import dataclass
 from typing import List, Optional
 
+from pydantic import BaseModel
 
-@dataclass
-class LaTeXError:
+
+class LaTeXError(BaseModel):
     """Represents a LaTeX error extracted from logs."""
 
     line_number: Optional[int]
@@ -15,8 +15,7 @@ class LaTeXError:
     context: Optional[str] = None
 
 
-@dataclass
-class LogSummary:
+class LogSummary(BaseModel):
     """Concise summary of LaTeX compilation log."""
 
     errors: List[LaTeXError]


### PR DESCRIPTION
## Summary
- Migrate `LaTeXError`, `LogSummary`, and `ValidationResult` from `dataclasses` to Pydantic `BaseModel`
- Part 1 of 3 for full Pydantic migration (HIGH priority backlog item)
- All 226 existing tests pass unchanged — zero regressions

## Changes
- `src/mcp_latex_tools/utils/log_parser.py`: `LaTeXError` and `LogSummary` → `BaseModel`
- `src/mcp_latex_tools/tools/validate.py`: `ValidationResult` → `BaseModel`
- `docs/development/ARCHITECTURE.md`: Added Pydantic migration status table
- `docs/tasks/26Q2-REFAC-01.md`: Task definition with acceptance criteria
- `docs/tasks/verify-26Q2-REFAC-01.sh`: Verification script

## Verification
```bash
$ bash docs/tasks/verify-26Q2-REFAC-01.sh
All 26Q2-REFAC-01 verification checks passed
```

## Checklist
- [x] All acceptance criteria met
- [x] Verification script passes
- [x] Tests pass (uv run pytest — 226 passed)
- [x] Code quality passes (ruff, mypy)
- [x] Documentation updated

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)