### PR TITLE
[26Q2-ENH-02] Configuration System

### DIFF
--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -70,6 +70,33 @@ Missing packages?
 | "Permission denied" | Check file/directory permissions |
 | Timeout | Increase `timeout` parameter (default: 30s) |
 
+## Configuration File
+
+Place a `.mcp-latex-tools.toml` in your project root to override defaults. All fields are optional:
+
+```toml
+[compilation]
+engine = "xelatex"    # default: "pdflatex"
+timeout = 60          # default: 30
+passes = "auto"       # default: 1
+
+[validation]
+strict = true         # default: false
+max_errors = 5        # default: 10
+
+[cleanup]
+dry_run = true        # default: false
+extensions = [".aux", ".log", ".out"]  # default: all 26 extensions
+
+[pdf_info]
+include_text = true   # default: false
+
+[detect_packages]
+check_installed = false  # default: true
+```
+
+MCP tool call arguments always override config file values.
+
 ## Parameter Defaults
 
 ### compile_latex

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -82,7 +82,6 @@ passes = "auto"       # default: 1
 
 [validation]
 strict = true         # default: false
-max_errors = 5        # default: 10
 
 [cleanup]
 dry_run = true        # default: false

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -33,6 +33,7 @@ MCP LaTeX Tools is a production-ready Model Context Protocol server providing La
 mcp-latex-tools/
 ├── src/mcp_latex_tools/
 │   ├── server.py              # MCP server entry point
+│   ├── config.py              # Configuration system (TOML-based)
 │   ├── tools/
 │   │   ├── compile.py         # LaTeX compilation (pdflatex/xelatex/lualatex/latexmk, multi-pass)
 │   │   ├── validate.py        # Syntax validation
@@ -42,6 +43,7 @@ mcp-latex-tools/
 │   └── utils/
 │       └── log_parser.py      # Token-optimized log parsing
 ├── tests/                     # Test suite (mirrors src structure)
+│   ├── test_config.py         # Configuration system tests
 │   ├── fixtures/              # Test fixture files
 │   ├── tools/                 # Tool unit tests
 │   │   ├── test_compile.py
@@ -68,11 +70,19 @@ mcp-latex-tools/
 
 ### Architectural Layers
 
+#### Layer 0: Configuration (config.py)
+- Loads project-level defaults from `.mcp-latex-tools.toml` (TOML via stdlib `tomllib`)
+- Pydantic v2 models: `ToolConfig` with sections for compilation, validation, cleanup, pdf_info, detect_packages
+- Walk-up file discovery (cwd → parent → ... → root)
+- Fail-open: malformed config logs warning, falls back to hardcoded defaults
+- Override precedence: MCP call args > config file > hardcoded defaults
+
 #### Layer 1: MCP Protocol Handler (server.py)
 - Handles MCP JSON-RPC communication
 - Routes tool calls to appropriate handlers
 - Formats responses for Claude Code consumption
 - Implements token-optimized output
+- Loads config at startup and uses it for default values
 
 #### Layer 2: Tool Implementation (tools/)
 - **compile.py**: LaTeX → PDF compilation with multi-engine (pdflatex/xelatex/lualatex/latexmk), multi-pass, and automatic bibliography (bibtex/biber) support
@@ -275,6 +285,7 @@ See [BACKLOG.md](BACKLOG.md) for the full feature backlog and prioritization.
 ---
 
 **Document Version History**:
+- 2026-04-06: Configuration system — TOML-based project config with Pydantic models (26Q2-ENH-02)
 - 2026-04-06: Test organization — tests moved into tools/, utils/, integration/ subdirectories (26Q2-DEBT-01)
 - 2026-04-06: Completed Pydantic migration — all 7 result classes (26Q2-REFAC-01/02/03)
 - 2026-04-05: Major rewrite — updated for post-cleanup architecture

--- a/docs/tasks/26Q2-ENH-02.md
+++ b/docs/tasks/26Q2-ENH-02.md
@@ -1,0 +1,86 @@
+### 26Q2-ENH-02: Configuration System
+
+**User Story**: As a user, I want to set project-level defaults in a config file so that I don't have to specify the same options on every MCP tool call.
+
+| Field | Value |
+|-------|-------|
+| **Story Points** | 3 |
+| **Priority** | MEDIUM |
+| **Status** | 🔄 IN PROGRESS |
+| **Branch** | `26Q2-ENH-02-configuration-system` |
+| **Dependencies** | None |
+| **PR Size Target** | <500 lines |
+
+---
+
+#### Context
+
+> Configuration is scattered across 6 files as hardcoded defaults. Users cannot customize defaults without modifying source code.
+
+**Current State**:
+- `compile.py`: `engine="pdflatex"`, `passes=1`, `timeout=None`
+- `server.py`: overrides `timeout=30`, duplicates `engine="pdflatex"`, `passes=1`
+- `cleanup.py`: `dry_run=False`, `recursive=False`, `create_backup=False`, `DEFAULT_CLEANUP_EXTENSIONS` (26 items)
+- `validate.py`: `quick=False`, `strict=False`
+- `pdf_info.py`: `include_text=False`
+- `detect_packages.py`: `check_installed=True`
+
+**Investigation**:
+```bash
+grep -rn "args.get" src/mcp_latex_tools/server.py | grep -c "False\|True\|pdflatex\|30"
+# Output: 8 hardcoded default values in server handlers
+```
+
+---
+
+#### Acceptance Criteria
+
+- [ ] `src/mcp_latex_tools/config.py` exists with `ToolConfig`, `CompilationConfig`, `ValidationConfig`, `CleanupConfig`, `PdfInfoConfig`, `DetectPackagesConfig` Pydantic models
+- [ ] `config.py` has `find_config_file(start_dir: Optional[Path]) -> Optional[Path]` that walks up from start_dir
+- [ ] `config.py` has `load_config(config_path: Optional[Path]) -> ToolConfig` that returns defaults on error
+- [ ] `ToolConfig()` default values match all current hardcoded defaults exactly
+- [ ] `server.py` loads config at module level and uses config values instead of hardcoded defaults in all 5 handlers
+- [ ] Config file format is TOML (`.mcp-latex-tools.toml`), parsed with stdlib `tomllib`
+- [ ] `tests/test_config.py` covers: default values, partial config, walk-up discovery, malformed TOML fallback, empty file, invalid types
+- [ ] All tests pass: `uv run pytest -v`
+- [ ] Type checking passes: `uv run mypy src/`
+- [ ] No lint errors: `uv run ruff check src/ tests/`
+
+---
+
+#### Files to Create/Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/mcp_latex_tools/config.py` | CREATE | Pydantic config models + TOML loader |
+| `tests/test_config.py` | CREATE | Config unit tests |
+| `src/mcp_latex_tools/server.py` | MODIFY | Load config, replace hardcoded defaults |
+| `docs/development/ARCHITECTURE.md` | MODIFY | Document config layer |
+| `docs/LLM_REFERENCE.md` | MODIFY | Document config file usage |
+
+---
+
+#### Implementation Notes
+
+- Use `tomllib` (stdlib Python 3.11+) — no new dependencies
+- Override precedence: MCP call args > config file > hardcoded defaults
+- Fail-open: malformed config logs warning, returns defaults
+- Config loads once at server startup (module-level)
+- `CleanupConfig.extensions` is `Optional[list[str]]` — `None` means use `DEFAULT_CLEANUP_EXTENSIONS`
+
+---
+
+#### Verification Script
+
+See `docs/tasks/verify-26Q2-ENH-02.sh`
+
+---
+
+#### Definition of Done
+
+- [ ] All acceptance criteria checked off
+- [ ] Verification script exits with code 0
+- [ ] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
+- [ ] PR created with <500 lines changed
+- [ ] Tests included with implementation
+- [ ] Documentation updated (LLM_REFERENCE.md, ARCHITECTURE.md)

--- a/docs/tasks/verify-26Q2-ENH-02.sh
+++ b/docs/tasks/verify-26Q2-ENH-02.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+echo "=== 26Q2-ENH-02: Configuration System Verification ==="
+
+# 1. Files exist
+echo "1. Checking files exist..."
+test -f src/mcp_latex_tools/config.py
+test -f tests/test_config.py
+echo "   OK"
+
+# 2. Config models present
+echo "2. Checking config models..."
+grep -q "class ToolConfig" src/mcp_latex_tools/config.py
+grep -q "class CompilationConfig" src/mcp_latex_tools/config.py
+grep -q "class ValidationConfig" src/mcp_latex_tools/config.py
+grep -q "class CleanupConfig" src/mcp_latex_tools/config.py
+grep -q "class PdfInfoConfig" src/mcp_latex_tools/config.py
+grep -q "class DetectPackagesConfig" src/mcp_latex_tools/config.py
+echo "   OK"
+
+# 3. Functions present
+echo "3. Checking functions..."
+grep -q "def find_config_file" src/mcp_latex_tools/config.py
+grep -q "def load_config" src/mcp_latex_tools/config.py
+echo "   OK"
+
+# 4. Uses tomllib (stdlib)
+echo "4. Checking tomllib usage..."
+grep -q "tomllib" src/mcp_latex_tools/config.py
+echo "   OK"
+
+# 5. Server integration
+echo "5. Checking server integration..."
+grep -q "from mcp_latex_tools.config import" src/mcp_latex_tools/server.py
+grep -q "_config" src/mcp_latex_tools/server.py
+echo "   OK"
+
+# 6. Import works
+echo "6. Checking imports..."
+uv run python -c "from mcp_latex_tools.config import ToolConfig, find_config_file, load_config; print('OK')"
+
+# 7. Default values match current defaults
+echo "7. Checking default values..."
+uv run python -c "
+from mcp_latex_tools.config import ToolConfig
+cfg = ToolConfig()
+assert cfg.compilation.engine == 'pdflatex'
+assert cfg.compilation.passes == 1
+assert cfg.compilation.timeout == 30
+assert cfg.validation.quick is False
+assert cfg.validation.strict is False
+assert cfg.validation.max_errors == 10
+assert cfg.cleanup.dry_run is False
+assert cfg.cleanup.recursive is False
+assert cfg.cleanup.create_backup is False
+assert cfg.cleanup.extensions is None
+assert cfg.pdf_info.include_text is False
+assert cfg.detect_packages.check_installed is True
+print('OK')
+"
+
+# 8. Config tests pass
+echo "8. Running config tests..."
+uv run pytest tests/test_config.py -v --tb=short
+
+# 9. Full suite (no regressions)
+echo "9. Running full test suite..."
+uv run pytest --tb=short -q
+
+# 10. Code quality
+echo "10. Running code quality checks..."
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+
+echo ""
+echo "=== All verification checks passed ==="

--- a/docs/tasks/verify-26Q2-ENH-02.sh
+++ b/docs/tasks/verify-26Q2-ENH-02.sh
@@ -50,7 +50,6 @@ assert cfg.compilation.passes == 1
 assert cfg.compilation.timeout == 30
 assert cfg.validation.quick is False
 assert cfg.validation.strict is False
-assert cfg.validation.max_errors == 10
 assert cfg.cleanup.dry_run is False
 assert cfg.cleanup.recursive is False
 assert cfg.cleanup.create_backup is False

--- a/src/mcp_latex_tools/config.py
+++ b/src/mcp_latex_tools/config.py
@@ -1,0 +1,110 @@
+"""Configuration system for mcp-latex-tools.
+
+Loads project-level defaults from a `.mcp-latex-tools.toml` file.
+Override precedence: MCP call args > config file > hardcoded defaults.
+"""
+
+import logging
+import tomllib
+from pathlib import Path
+from typing import Optional, Union
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+CONFIG_FILENAME = ".mcp-latex-tools.toml"
+
+
+class CompilationConfig(BaseModel):
+    """Defaults for the compile_latex tool."""
+
+    engine: str = "pdflatex"
+    passes: Union[int, str] = 1
+    timeout: int = 30
+
+
+class ValidationConfig(BaseModel):
+    """Defaults for the validate_latex tool."""
+
+    quick: bool = False
+    strict: bool = False
+    max_errors: int = 10
+
+
+class CleanupConfig(BaseModel):
+    """Defaults for the cleanup tool."""
+
+    dry_run: bool = False
+    recursive: bool = False
+    create_backup: bool = False
+    extensions: Optional[list[str]] = None
+
+
+class PdfInfoConfig(BaseModel):
+    """Defaults for the pdf_info tool."""
+
+    include_text: bool = False
+
+
+class DetectPackagesConfig(BaseModel):
+    """Defaults for the detect_packages tool."""
+
+    check_installed: bool = True
+
+
+class ToolConfig(BaseModel):
+    """Root configuration for mcp-latex-tools."""
+
+    compilation: CompilationConfig = CompilationConfig()
+    validation: ValidationConfig = ValidationConfig()
+    cleanup: CleanupConfig = CleanupConfig()
+    pdf_info: PdfInfoConfig = PdfInfoConfig()
+    detect_packages: DetectPackagesConfig = DetectPackagesConfig()
+
+
+def find_config_file(start_dir: Optional[Path] = None) -> Optional[Path]:
+    """Search for .mcp-latex-tools.toml, walking up from start_dir to root.
+
+    Args:
+        start_dir: Directory to start searching from. Defaults to cwd.
+
+    Returns:
+        Path to the config file if found, None otherwise.
+    """
+    current = (start_dir or Path.cwd()).resolve()
+    while True:
+        candidate = current / CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def load_config(config_path: Optional[Path] = None) -> ToolConfig:
+    """Load configuration from a TOML file.
+
+    Args:
+        config_path: Explicit path to config file. If None, searches
+            for .mcp-latex-tools.toml walking up from cwd.
+
+    Returns:
+        ToolConfig instance. Returns default config if no file found
+        or if file cannot be parsed.
+    """
+    if config_path is None:
+        config_path = find_config_file()
+
+    if config_path is None or not config_path.is_file():
+        return ToolConfig()
+
+    try:
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+        return ToolConfig.model_validate(data)
+    except Exception as e:
+        logger.warning("Failed to load config from %s: %s", config_path, e)
+        return ToolConfig()

--- a/src/mcp_latex_tools/config.py
+++ b/src/mcp_latex_tools/config.py
@@ -7,7 +7,7 @@ Override precedence: MCP call args > config file > hardcoded defaults.
 import logging
 import tomllib
 from pathlib import Path
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel
 
@@ -20,7 +20,7 @@ class CompilationConfig(BaseModel):
     """Defaults for the compile_latex tool."""
 
     engine: str = "pdflatex"
-    passes: Union[int, str] = 1
+    passes: Union[int, Literal["auto"]] = 1
     timeout: int = 30
 
 
@@ -29,7 +29,6 @@ class ValidationConfig(BaseModel):
 
     quick: bool = False
     strict: bool = False
-    max_errors: int = 10
 
 
 class CleanupConfig(BaseModel):

--- a/src/mcp_latex_tools/server.py
+++ b/src/mcp_latex_tools/server.py
@@ -30,6 +30,7 @@ from mcp_latex_tools.tools.detect_packages import (
     detect_packages,
     PackageDetectionError,
 )
+from mcp_latex_tools.config import load_config
 from mcp_latex_tools.utils.log_parser import get_error_summary
 
 logging.basicConfig(
@@ -39,6 +40,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 server: Server = Server("mcp-latex-tools")
+_config = load_config()
 
 
 @server.list_tools()
@@ -452,8 +454,8 @@ async def _handle_compile(args: dict) -> list[TextContent]:
             "Error: tex_path is required. Pass the path to the .tex file."
         )
 
-    engine = args.get("engine", "pdflatex")
-    passes = args.get("passes", 1)
+    engine = args.get("engine", _config.compilation.engine)
+    passes = args.get("passes", _config.compilation.passes)
 
     try:
         loop = asyncio.get_running_loop()
@@ -462,7 +464,7 @@ async def _handle_compile(args: dict) -> list[TextContent]:
             lambda: compile_latex(
                 tex_path,
                 output_dir=args.get("output_dir"),
-                timeout=args.get("timeout", 30),
+                timeout=args.get("timeout", _config.compilation.timeout),
                 engine=engine,
                 passes=passes,
             ),
@@ -504,8 +506,8 @@ async def _handle_validate(args: dict) -> list[TextContent]:
             None,
             validate_latex,
             file_path,
-            args.get("quick", False),
-            args.get("strict", False),
+            args.get("quick", _config.validation.quick),
+            args.get("strict", _config.validation.strict),
         )
 
         if result.is_valid:
@@ -538,7 +540,7 @@ async def _handle_pdf_info(args: dict) -> list[TextContent]:
             "Error: file_path is required. Pass the path to the PDF file."
         )
 
-    include_text = args.get("include_text", False)
+    include_text = args.get("include_text", _config.pdf_info.include_text)
     try:
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
@@ -601,10 +603,10 @@ async def _handle_cleanup(args: dict) -> list[TextContent]:
             None,
             clean_latex,
             path,
-            args.get("extensions"),
-            args.get("dry_run", False),
-            args.get("recursive", False),
-            args.get("create_backup", False),
+            args.get("extensions", _config.cleanup.extensions),
+            args.get("dry_run", _config.cleanup.dry_run),
+            args.get("recursive", _config.cleanup.recursive),
+            args.get("create_backup", _config.cleanup.create_backup),
         )
 
         if result.success:
@@ -653,7 +655,9 @@ async def _handle_detect_packages(args: dict) -> list[TextContent]:
             "Error: file_path is required. Pass the path to the .tex file."
         )
 
-    check_installed = args.get("check_installed", True)
+    check_installed = args.get(
+        "check_installed", _config.detect_packages.check_installed
+    )
 
     try:
         loop = asyncio.get_running_loop()

--- a/src/mcp_latex_tools/server.py
+++ b/src/mcp_latex_tools/server.py
@@ -40,6 +40,9 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 server: Server = Server("mcp-latex-tools")
+# Config loaded once at startup; provides runtime defaults for tool handlers.
+# Note: "default" values in the MCP inputSchema below are informational for
+# MCP clients and may differ from runtime config file overrides.
 _config = load_config()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,6 @@ class TestToolConfigDefaults:
         cfg = ToolConfig()
         assert cfg.validation.quick is False
         assert cfg.validation.strict is False
-        assert cfg.validation.max_errors == 10
 
     def test_default_cleanup(self) -> None:
         cfg = ToolConfig()
@@ -83,6 +82,10 @@ class TestToolConfigPartial:
     def test_invalid_timeout_type_rejected(self) -> None:
         with pytest.raises(ValidationError):
             CompilationConfig(timeout="not_a_number")  # type: ignore[arg-type]
+
+    def test_invalid_passes_string_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CompilationConfig(passes="banana")  # type: ignore[arg-type]
 
     def test_invalid_dry_run_type_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -173,7 +176,7 @@ class TestLoadConfig:
         cfg_file = tmp_path / CONFIG_FILENAME
         cfg_file.write_text(
             '[compilation]\nengine = "lualatex"\npasses = "auto"\ntimeout = 120\n\n'
-            "[validation]\nstrict = true\nmax_errors = 5\n\n"
+            "[validation]\nstrict = true\n\n"
             '[cleanup]\ndry_run = true\nextensions = [".aux", ".log"]\n\n'
             "[pdf_info]\ninclude_text = true\n\n"
             "[detect_packages]\ncheck_installed = false\n"
@@ -183,7 +186,6 @@ class TestLoadConfig:
         assert cfg.compilation.passes == "auto"
         assert cfg.compilation.timeout == 120
         assert cfg.validation.strict is True
-        assert cfg.validation.max_errors == 5
         assert cfg.cleanup.dry_run is True
         assert cfg.cleanup.extensions == [".aux", ".log"]
         assert cfg.pdf_info.include_text is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,208 @@
+"""Tests for mcp_latex_tools.config — configuration system."""
+
+import pytest
+from pathlib import Path
+from pydantic import ValidationError
+
+from mcp_latex_tools.config import (
+    CONFIG_FILENAME,
+    CompilationConfig,
+    CleanupConfig,
+    ToolConfig,
+    find_config_file,
+    load_config,
+)
+
+
+class TestToolConfigDefaults:
+    """ToolConfig() with no arguments must match all current hardcoded defaults."""
+
+    def test_default_compilation(self) -> None:
+        cfg = ToolConfig()
+        assert cfg.compilation.engine == "pdflatex"
+        assert cfg.compilation.passes == 1
+        assert cfg.compilation.timeout == 30
+
+    def test_default_validation(self) -> None:
+        cfg = ToolConfig()
+        assert cfg.validation.quick is False
+        assert cfg.validation.strict is False
+        assert cfg.validation.max_errors == 10
+
+    def test_default_cleanup(self) -> None:
+        cfg = ToolConfig()
+        assert cfg.cleanup.dry_run is False
+        assert cfg.cleanup.recursive is False
+        assert cfg.cleanup.create_backup is False
+        assert cfg.cleanup.extensions is None
+
+    def test_default_pdf_info(self) -> None:
+        cfg = ToolConfig()
+        assert cfg.pdf_info.include_text is False
+
+    def test_default_detect_packages(self) -> None:
+        cfg = ToolConfig()
+        assert cfg.detect_packages.check_installed is True
+
+
+class TestToolConfigPartial:
+    """Partial config data fills remaining fields with defaults."""
+
+    def test_partial_compilation_section(self) -> None:
+        cfg = ToolConfig.model_validate({"compilation": {"engine": "xelatex"}})
+        assert cfg.compilation.engine == "xelatex"
+        assert cfg.compilation.timeout == 30
+        assert cfg.compilation.passes == 1
+
+    def test_partial_sections_fill_defaults(self) -> None:
+        cfg = ToolConfig.model_validate({"cleanup": {"dry_run": True}})
+        assert cfg.cleanup.dry_run is True
+        assert cfg.compilation.engine == "pdflatex"
+        assert cfg.validation.quick is False
+
+    def test_full_config_from_dict(self) -> None:
+        data = {
+            "compilation": {"engine": "lualatex", "passes": "auto", "timeout": 120},
+            "cleanup": {"dry_run": True, "extensions": [".aux", ".log"]},
+        }
+        cfg = ToolConfig.model_validate(data)
+        assert cfg.compilation.engine == "lualatex"
+        assert cfg.compilation.passes == "auto"
+        assert cfg.compilation.timeout == 120
+        assert cfg.cleanup.dry_run is True
+        assert cfg.cleanup.extensions == [".aux", ".log"]
+
+    def test_compilation_passes_accepts_int(self) -> None:
+        cfg = CompilationConfig(passes=3)
+        assert cfg.passes == 3
+
+    def test_compilation_passes_accepts_auto(self) -> None:
+        cfg = CompilationConfig(passes="auto")
+        assert cfg.passes == "auto"
+
+    def test_invalid_timeout_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CompilationConfig(timeout="not_a_number")  # type: ignore[arg-type]
+
+    def test_invalid_dry_run_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CleanupConfig(dry_run=[1, 2])  # type: ignore[arg-type]
+
+
+class TestFindConfigFile:
+    """Config file discovery — walk up from start_dir to root."""
+
+    def test_finds_config_in_start_dir(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text('[compilation]\nengine = "xelatex"\n')
+        result = find_config_file(start_dir=tmp_path)
+        assert result == cfg_file
+
+    def test_finds_config_in_parent_dir(self, tmp_path: Path) -> None:
+        child = tmp_path / "subdir"
+        child.mkdir()
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text('[compilation]\nengine = "xelatex"\n')
+        result = find_config_file(start_dir=child)
+        assert result == cfg_file
+
+    def test_finds_config_in_grandparent_dir(self, tmp_path: Path) -> None:
+        grandchild = tmp_path / "a" / "b"
+        grandchild.mkdir(parents=True)
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text('[compilation]\nengine = "xelatex"\n')
+        result = find_config_file(start_dir=grandchild)
+        assert result == cfg_file
+
+    def test_returns_none_when_no_config(self, tmp_path: Path) -> None:
+        result = find_config_file(start_dir=tmp_path)
+        assert result is None
+
+    def test_nearest_config_wins(self, tmp_path: Path) -> None:
+        parent_cfg = tmp_path / CONFIG_FILENAME
+        parent_cfg.write_text('[compilation]\nengine = "pdflatex"\n')
+        child = tmp_path / "subdir"
+        child.mkdir()
+        child_cfg = child / CONFIG_FILENAME
+        child_cfg.write_text('[compilation]\nengine = "xelatex"\n')
+        result = find_config_file(start_dir=child)
+        assert result == child_cfg
+
+
+class TestLoadConfig:
+    """Config loading from TOML files."""
+
+    def test_load_valid_toml(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text('[compilation]\nengine = "xelatex"\ntimeout = 60\n')
+        cfg = load_config(config_path=cfg_file)
+        assert cfg.compilation.engine == "xelatex"
+        assert cfg.compilation.timeout == 60
+
+    def test_load_returns_defaults_when_no_file(self, tmp_path: Path) -> None:
+        # Explicit non-existent path
+        cfg = load_config(config_path=tmp_path / "nonexistent.toml")
+        assert cfg == ToolConfig()
+
+    def test_load_returns_defaults_on_malformed_toml(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text("this is not [[ valid toml")
+        cfg = load_config(config_path=cfg_file)
+        assert cfg == ToolConfig()
+
+    def test_load_returns_defaults_on_invalid_values(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text('[compilation]\ntimeout = "not_a_number"\n')
+        cfg = load_config(config_path=cfg_file)
+        assert cfg == ToolConfig()
+
+    def test_load_partial_sections(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text("[cleanup]\ndry_run = true\n")
+        cfg = load_config(config_path=cfg_file)
+        assert cfg.cleanup.dry_run is True
+        assert cfg.compilation.engine == "pdflatex"
+
+    def test_load_empty_file(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text("")
+        cfg = load_config(config_path=cfg_file)
+        assert cfg == ToolConfig()
+
+    def test_load_with_all_sections(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text(
+            '[compilation]\nengine = "lualatex"\npasses = "auto"\ntimeout = 120\n\n'
+            "[validation]\nstrict = true\nmax_errors = 5\n\n"
+            '[cleanup]\ndry_run = true\nextensions = [".aux", ".log"]\n\n'
+            "[pdf_info]\ninclude_text = true\n\n"
+            "[detect_packages]\ncheck_installed = false\n"
+        )
+        cfg = load_config(config_path=cfg_file)
+        assert cfg.compilation.engine == "lualatex"
+        assert cfg.compilation.passes == "auto"
+        assert cfg.compilation.timeout == 120
+        assert cfg.validation.strict is True
+        assert cfg.validation.max_errors == 5
+        assert cfg.cleanup.dry_run is True
+        assert cfg.cleanup.extensions == [".aux", ".log"]
+        assert cfg.pdf_info.include_text is True
+        assert cfg.detect_packages.check_installed is False
+
+    def test_load_ignores_unknown_keys(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text(
+            '[compilation]\nengine = "xelatex"\nfuture_key = "ignored"\n'
+        )
+        cfg = load_config(config_path=cfg_file)
+        assert cfg.compilation.engine == "xelatex"
+
+    def test_load_autodiscover_from_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_config() with no args discovers config via find_config_file."""
+        cfg_file = tmp_path / CONFIG_FILENAME
+        cfg_file.write_text('[compilation]\nengine = "xelatex"\n')
+        monkeypatch.chdir(tmp_path)
+        cfg = load_config()
+        assert cfg.compilation.engine == "xelatex"


### PR DESCRIPTION
## Summary
- Add TOML-based config file (`.mcp-latex-tools.toml`) with Pydantic v2 models
- Config loads at server startup; MCP tool call args override config values
- Walk-up file discovery from cwd to root, fail-open on errors
- No new dependencies (uses stdlib `tomllib`)
- Replaces hardcoded defaults in all 5 server handlers

Closes #20

## Changes
- **NEW** `src/mcp_latex_tools/config.py` — 6 Pydantic config models + `find_config_file` + `load_config`
- **NEW** `tests/test_config.py` — 26 tests (defaults, partial config, discovery, TOML loading, error handling)
- **MODIFIED** `src/mcp_latex_tools/server.py` — Load config at startup, use config defaults in handlers
- **MODIFIED** `docs/development/ARCHITECTURE.md` — Document config layer
- **MODIFIED** `docs/LLM_REFERENCE.md` — Document config file format

## Verification
```bash
$ bash docs/tasks/verify-26Q2-ENH-02.sh
All verification checks passed
```

## Checklist
- [x] All acceptance criteria met
- [x] Verification script passes
- [x] Tests pass (uv run pytest)
- [x] Code quality passes (ruff, mypy)
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)